### PR TITLE
Implement single-track lateral-force-only Pacejka dynamics model, "STP"

### DIFF
--- a/docs/plan/SINGLE_TRACK_PACEJKA.md
+++ b/docs/plan/SINGLE_TRACK_PACEJKA.md
@@ -1,0 +1,146 @@
+# Port `STDKinematics::update_pacejka` from f110-simulator into gymkhana
+
+## Context
+
+The f110-simulator (`race_stack/base_system/f110-simulator/src/std_kinematics.cpp`) implements a **dynamic single-track model with a Pacejka Magic Formula tire law on the lateral axis only** (`update_pacejka`, lines 14–133). This model is exactly what `system_identification/on_track_sys_id` identifies — its output is 8 Pacejka coefficients (`B,C,D,E` per axle) plus a steady-state `(v_x, δ) → a_lat` LUT. The `SIM_pacejka.txt` file already contains a 1/10-scale identification.
+
+Gymkhana (`race_stack/base_system/gymkhana/`) currently offers four models: `KS, ST, MB, STD`. The existing `STD` model (`single_track_drift/single_track_drift.py`) uses the *full PAC2002* tire model with longitudinal slip and wheel-spin states (9-state vector, `R_w, I_y_w, T_sb, T_se`) — heavier than `update_pacejka` and not directly compatible with sysid output. The `ST` model uses linear cornering stiffness with small-angle linearizations and cannot be tire-law-swapped in place because its `ψ̈` and `β̇` formulas are closed-form expansions that only exist *because* `F_y` is linear in `α, β, δ` (see `single_track.py:111–127`).
+
+We want a new gymkhana model that mirrors `update_pacejka` exactly: 7-state ST-shaped vector (no longitudinal slip / wheel-spin), Pacejka lateral tires, full nonlinear ODE (no small-angle approximations), low-speed kinematic blend. Goal: drop in identified Pacejka coefficients from `on_track_sys_id` and have a faithful 1/10 dynamics model in the RL training loop.
+
+## Recommended approach
+
+Add a new dynamics module `STP` (Single Track Pacejka), parallel to `single_track.py` and `single_track_drift/`. Do not modify `ST`, `STD`, or `KS`. The structure mirrors the f110 implementation directly (`F_y` as named intermediates → body-frame `(v̇_x, v̇_y, ψ̈)` → chain-rule into `(V̇, β̇)`), with derivative-level low-speed blending and gymkhana-style constraints applied inside `f`.
+
+Per resolved design decisions:
+- **Naming:** `DynamicModel.STP`, `vehicle_dynamics_stp`, folder `single_track_pacejka/`.
+- **`mu` kept explicit** as a multiplier on `F_y` (matches f110 `update_pacejka`; lets user disable by setting `mu=1.0`).
+- **Initial params:** new YAML seeded from `system_identification/on_track_sys_id/models/SIM/SIM_pacejka.txt`.
+
+### Files to create
+
+1. **`race_stack/base_system/gymkhana/envs/dynamic_models/single_track_pacejka/__init__.py`**
+   - Re-export `vehicle_dynamics_stp`, `get_standardized_state_stp`.
+   - No `init_stp` needed — 7-state init is identical to ST (handled by the existing zero-init path in `DynamicModel.get_initial_state`).
+
+2. **`race_stack/base_system/gymkhana/envs/dynamic_models/single_track_pacejka/single_track_pacejka.py`**
+   - `def vehicle_dynamics_stp(x, u_init, params) -> np.ndarray` returning shape `(7,)`.
+   - State: `[X, Y, δ, V, ψ, ψ̇, β]` (same as ST, same `get_standardized_state_st` semantics).
+   - Inputs: `[STEER_VEL, ACCL]`.
+   - Implementation steps inside the function:
+     1. Apply `steering_constraint(...)` and `accl_constraints(...)` from `..utils` (same pattern as `single_track.py:50–69`).
+     2. Compute slip angles with `V > v_min` guard (gymkhana sign convention, equivalent to f110's `atan2(-v_y - l_f·ω, v_x) + δ`):
+        ```python
+        alpha_f = np.arctan((V*sin(β) + ψ̇*l_f) / (V*cos(β))) - δ   if V > v_min else 0.0
+        alpha_r = np.arctan((V*sin(β) - ψ̇*l_r) / (V*cos(β)))       if V > v_min else 0.0
+        ```
+     3. Vertical loads with longitudinal weight transfer (uses `params["h_s"]` to align with STD naming):
+        ```python
+        F_zf = m * (-ACCL*h_s + g*l_r) / (l_f + l_r)
+        F_zr = m * ( ACCL*h_s + g*l_f) / (l_f + l_r)
+        ```
+     4. Pacejka lateral forces with explicit `mu` multiplier (mirrors `std_kinematics.cpp:69–76`):
+        ```python
+        F_yf = mu * D_f * F_zf * sin(C_f * arctan(B_f*α_f - E_f*(B_f*α_f - arctan(B_f*α_f))))
+        F_yr = mu * D_r * F_zr * sin(C_r * arctan(B_r*α_r - E_r*(B_r*α_r - arctan(B_r*α_r))))
+        ```
+     5. Body-frame derivatives, **exact, no small-angle** (mirrors `std_kinematics.cpp:84,87,88`), substituting `v_x = V·cos β`, `v_y = V·sin β`:
+        ```python
+        v_x_dot = ACCL - (1/m)*F_yf*sin(δ) + V*sin(β)*ψ̇
+        v_y_dot = (1/m)*(F_yr + F_yf*cos(δ)) - V*cos(β)*ψ̇
+        psi_ddot = (1/I_z)*(-F_yr*l_r + F_yf*l_f*cos(δ))
+        ```
+     6. Chain-rule into `(V̇, β̇)` (this is the gymkhana-vs-f110 parametrization difference; only needed because state stores `V, β` not `v_x, v_y`):
+        ```python
+        V_dot   = v_x_dot*cos(β) + v_y_dot*sin(β)
+        beta_dot = (v_y_dot*cos(β) - v_x_dot*sin(β)) / max(V, v_min)
+        ```
+     7. Compute kinematic-bicycle derivatives by calling `vehicle_dynamics_ks_cog` from `..kinematic` with the projected 5-state `[X, Y, δ, V, ψ]`. This is the same pattern STD uses (`single_track_drift.py:182`) and avoids reimplementing kinematic equations.
+     8. Blend **derivatives** (not states) with `tanh` weights — gymkhana-scale thresholds, *not* the f110 `v_b=3, v_s=1` defaults (those were tuned for full-scale velocities and would leave a 1/10 car kinematic almost always):
+        ```python
+        v_s = 0.2;  v_b = 0.05            # follow STD's choice (line 69–70)
+        w_std = 0.5 * (np.tanh((V - v_s) / v_b) + 1)
+        w_ks  = 1 - w_std
+        ```
+        For the kinematic side: `V_dot_ks = ACCL`, `psi_dot_ks = f_ks[4]`, `beta_dot_ks = (lr*STEER_VEL)/(lwb*cos²δ*(1+(tan²δ·lr/lwb)²))` (closed-form from STD line 184), `psi_ddot_ks` from STD line 187.
+     9. Assemble the 7-vector:
+        ```python
+        f = np.array([
+            V*cos(ψ + β),
+            V*sin(ψ + β),
+            STEER_VEL,
+            w_std*V_dot    + w_ks*ACCL,
+            ψ̇,                              # PSI_DOT (state pass-through; same in dyn and kin)
+            w_std*psi_ddot + w_ks*psi_ddot_ks,
+            w_std*beta_dot + w_ks*beta_dot_ks,
+        ])
+        ```
+   - `def get_standardized_state_stp(x)`: identical to `get_standardized_state_st` (same 7-element state, same `(V, β)` → `(v_x, v_y)` decomposition). Re-export from `single_track.py` to avoid duplication, OR define a thin alias.
+
+3. **`race_stack/base_system/gymkhana/envs/params/f1tenth_stp.yaml`**
+   - Copy geometry/inertia/constraints from `f1tenth_std.yaml` (mass, `lf`, `lr`, `h_s`, `I_z`, `s_min/max`, `sv_min/max`, `v_switch`, `a_max`, `v_min/max`, `width`, `length`).
+   - Add `mu: 1.0489` (carry over from `f1tenth_st.yaml` line 8).
+   - Add 8 Pacejka coefficients seeded from `on_track_sys_id/models/SIM/SIM_pacejka.txt`:
+     ```yaml
+     B_f: 6.6185;  C_f: 1.6102;  D_f: 0.652;   E_f: 0.7826
+     B_r: 7.9507;  C_r: 3.692;   D_r: 0.6691;  E_r: 0.5595
+     ```
+   - Note in a comment that `D` is dimensionless (peak μ-equivalent) and that sysid output sets `mu=1.0` since μ is folded into `D`. With `mu=1.0489` here we are slightly scaling up the identified peak — flag this for the user; they may want to change `mu: 1.0` for sysid-faithful behavior.
+   - Drop wheel-dynamics keys (`R_w`, `I_y_w`, `T_sb`, `T_se`) and full-PAC2002 tire keys (`tire_p_cx1`, ..., `tire_r_vy6`) — STP doesn't use them.
+
+### Files to modify
+
+4. **`race_stack/base_system/gymkhana/envs/dynamic_models/__init__.py`**
+   - Import `vehicle_dynamics_stp, get_standardized_state_stp` from `.single_track_pacejka`.
+   - Add `DynamicModel.STP = 5` enum member with docstring.
+   - Extend `DynamicModel.from_string`: accept `"stp"`.
+   - Extend `DynamicModel.get_initial_state`: STP uses 7-element zero-init (identical to ST branch — extend the existing ST branch or add a parallel branch). No `init_*` inflation.
+   - Extend `DynamicModel.f_dynamics`: return `vehicle_dynamics_stp` for STP.
+   - Extend `DynamicModel.get_standardized_state_fn`: return `get_standardized_state_stp` for STP.
+   - Update the module docstring's tire-parameter section to list `B_f, C_f, D_f, E_f, B_r, C_r, D_r, E_r` (STP-only).
+
+5. **`race_stack/base_system/gymkhana/envs/gymkhana_env.py`**
+   - Add `@classmethod GKEnv.f1tenth_stp_vehicle_params(cls) -> dict: return load_params("f1tenth_stp")`. Mirror the existing `f1tenth_std_vehicle_params` (line 452).
+   - No changes to `default_config`, `step`, integrator wiring, or observation handling — STP plugs into the existing `self.integrator.integrate(f=f_dynamics, ...)` path (`base_classes.py:354`) automatically once `f_dynamics` is wired.
+
+### Functions to reuse (do not reimplement)
+
+- `vehicle_dynamics_ks_cog` from `envs/dynamic_models/kinematic.py:76` — kinematic blend partner.
+- `steering_constraint`, `accl_constraints` from `envs/dynamic_models/utils.py` — input limits.
+- `get_standardized_state_st` from `envs/dynamic_models/single_track.py:135` — state shape is identical, can alias.
+- `load_params` (already used in `gymkhana_env.py`) — YAML loader.
+- The `RK4Integrator` in `envs/integrator.py:32` — works as-is on any `f(x, u, params)`.
+
+## Critical implementation notes
+
+- **Sign convention for `α`**: Use the gymkhana convention `α_f = atan(...) - δ` (matches `single_track_drift.py:99` and is algebraically equivalent to f110's `atan2(-v_y - l_f·ω, v_x) + δ` for `V > 0`). The Pacejka curve is odd, so `F_y(α)` flips sign accordingly; the body-frame equations as written above already match this convention. Sanity-check after implementation: positive `δ` → vehicle yaws left.
+- **Don't apply small-angle approximations** anywhere in the STP function. The whole point of Pacejka is large-slip behavior; linearizing defeats the purpose and the STD f110 code keeps `cos δ`, `sin δ`, `cos β`, `sin β` exact.
+- **Mix derivatives, not states.** RK4 evaluates `f` four times per step; mixing post-integration states (as f110 does under Euler) is incompatible with the gymkhana integrator architecture. STD already shows the correct derivative-mix pattern.
+- **Guard `1/V` and `1/cos β`** in α and `β_dot`. Use `if V > v_min` early returns where divisions appear, matching STD line 99–100.
+- **RK4 may evaluate at slightly non-physical intermediate states** (`V` near zero or marginally negative). The blend tanh and the `V > v_min` guards handle this gracefully — same as STD.
+- **Constraints inside `f`** (gymkhana convention), not outside (f110 convention).
+
+## Verification
+
+End-to-end checks, executable from the gymkhana root:
+
+1. **Smoke test — straight line, no steering:**
+   ```python
+   env = GKEnv(config={"model": "stp", "params": GKEnv.f1tenth_stp_vehicle_params()})
+   obs, _ = env.reset()
+   for _ in range(200):
+       env.step(np.array([0.0, 1.0]))   # zero steering, accel=1 m/s²
+   # Expect: V increases linearly, β stays ≈ 0, ψ̇ stays ≈ 0, X grows, Y stays ≈ 0.
+   ```
+
+2. **Low-slip equivalence with ST:** at low cornering accelerations and `V ≈ 3 m/s`, STP with sysid params should produce trajectories close to ST (linearization regime). Roll out same `(STEER_VEL, ACCL)` schedule under both `model="st"` and `model="stp"`; expect `|x_st - x_stp| < O(1cm)` over 1 s.
+
+3. **Tire saturation:** apply a step steering input of 0.4 rad at `V = 6 m/s`. Plot `F_yf` and `F_yr` (expose as a debug return or compute offline from state). Expect both to saturate near `D · F_z` rather than growing unboundedly (which is the failure mode of ST in this regime).
+
+4. **Low-speed blend smoothness:** start at `V = 0.05` m/s and accelerate through `V = 0.5` m/s. Plot `β` and `ψ̇` over time — should be C¹ smooth across the threshold (no jumps), confirming the tanh derivative-blend works.
+
+5. **Drift bias check:** with rear-axle Pacejka coefficients reduced (e.g. `D_r *= 0.6`), expect the car to oversteer / spin under hard cornering — confirms rear tires saturate first as physics dictates.
+
+6. **Integration compatibility:** confirm both `integrator: "rk4"` (default) and `integrator: "euler"` produce stable rollouts for the same input schedule (no NaN, no divergence).
+
+7. **Sysid round-trip (optional, longer-term):** drop the LUT generated by `on_track_sys_id` for SIM into `system_identification/steering_lookup/cfg/` and run a MAP-controlled time trial in this gymkhana env with `model="stp"`. Should produce coherent racing behavior — validates the parameter-set compatibility end-to-end.

--- a/examples/analysis/model_validation/test_compare_stp.py
+++ b/examples/analysis/model_validation/test_compare_stp.py
@@ -1,0 +1,172 @@
+"""
+Compares behaviour of the STP (Single Track Pacejka) model against the ST
+(Single Track) model on 1/10 scale F1TENTH parameters. Pure visual comparison.
+
+Scenarios:
+  1. Linear-regime cornering: low speed, low steering -> models should agree.
+  2. Saturation cornering: higher speed and steering -> STP saturates, ST does not.
+  3. Steady-state understeer sweep: yaw rate vs steering target at fixed speed.
+  4. Low-speed kinematic blend: ST hard-switch vs STP tanh-blend across the threshold.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.integrate import odeint
+
+from gymkhana.envs.dynamic_models.single_track import vehicle_dynamics_st
+from gymkhana.envs.dynamic_models.single_track_pacejka.single_track_pacejka import vehicle_dynamics_stp
+from gymkhana.envs.gymkhana_env import GKEnv
+
+# ST and STP take incompatible parameter dicts (linear stiffness vs Pacejka coeffs),
+# so each model gets its own param set. Both yamls are tuned for the 1/10 scale car.
+p_st = GKEnv.f1tenth_vehicle_params()
+p_stp = GKEnv.f1tenth_stp_vehicle_params()
+
+
+def func_ST(x, t, u, p):
+    return vehicle_dynamics_st(x, u, p)
+
+
+def func_STP(x, t, u, p):
+    return vehicle_dynamics_stp(x, u, p)
+
+
+def _initial_state(vel0):
+    # [x, y, delta, V, psi, psi_dot, beta]
+    return np.array([0.0, 0.0, 0.0, vel0, 0.0, 0.0, 0.0])
+
+
+def _plot_pair(t, x_st, x_stp, suptitle):
+    _, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(15, 4))
+
+    ax1.set_title("trajectory")
+    ax1.plot([s[0] for s in x_st], [s[1] for s in x_st])
+    ax1.plot([s[0] for s in x_stp], [s[1] for s in x_stp])
+    ax1.set_xlabel("x [m]")
+    ax1.set_ylabel("y [m]")
+    ax1.set_aspect("equal", adjustable="datalim")
+    ax1.legend(["ST", "STP"])
+
+    ax2.set_title("slip angle")
+    ax2.plot(t, [s[6] for s in x_st])
+    ax2.plot(t, [s[6] for s in x_stp])
+    ax2.set_xlabel("t [s]")
+    ax2.set_ylabel("beta [rad]")
+    ax2.legend(["ST", "STP"])
+
+    ax3.set_title("yaw rate")
+    ax3.plot(t, [s[5] for s in x_st])
+    ax3.plot(t, [s[5] for s in x_stp])
+    ax3.set_xlabel("t [s]")
+    ax3.set_ylabel("psi_dot [rad/s]")
+    ax3.legend(["ST", "STP"])
+
+    plt.suptitle(suptitle)
+    plt.tight_layout()
+    plt.show()
+
+
+def compare_linear_cornering():
+    """Low speed, low steering -- STP should track ST closely in the linear tire regime."""
+    vel0 = 3.0
+    v_delta = 0.05
+    a_long = 0.0
+    tFinal = 2.0
+
+    t = np.arange(0, tFinal, 0.01)
+    u = [v_delta, a_long]
+    x0 = _initial_state(vel0)
+
+    x_st = odeint(func_ST, x0, t, args=(u, p_st))
+    x_stp = odeint(func_STP, x0, t, args=(u, p_stp))
+
+    _plot_pair(t, x_st, x_stp, f"Linear-regime cornering  (vel0={vel0}, v_delta={v_delta})")
+
+
+def compare_saturation_cornering():
+    """Higher speed and steering -- Pacejka saturation should diverge from ST's linear forces."""
+    vel0 = 7.0
+    v_delta = 0.4
+    a_long = 0.0
+    tFinal = 1.5
+
+    t = np.arange(0, tFinal, 0.01)
+    u = [v_delta, a_long]
+    x0 = _initial_state(vel0)
+
+    x_st = odeint(func_ST, x0, t, args=(u, p_st))
+    x_stp = odeint(func_STP, x0, t, args=(u, p_stp))
+
+    _plot_pair(t, x_st, x_stp, f"Saturation cornering  (vel0={vel0}, v_delta={v_delta})")
+
+
+def compare_understeer_sweep():
+    """Steady-state yaw rate vs steering target at fixed speed.
+
+    For each delta target: ramp steering linearly over t_ramp, then hold steer_vel=0
+    and integrate to settle. Record final psi_dot. ST yields a near-linear curve;
+    STP curls over as the tires saturate -- the textbook understeer signature.
+    """
+    vel0 = 5.0
+    t_ramp = 0.5
+    t_settle = 3.0
+    delta_targets = np.linspace(0.02, 0.4, 12)
+
+    t1 = np.arange(0, t_ramp, 0.01)
+    t2 = np.arange(0, t_settle, 0.01)
+
+    psi_dot_ss_st = []
+    psi_dot_ss_stp = []
+    for delta_t in delta_targets:
+        v_delta = delta_t / t_ramp
+        x0 = _initial_state(vel0)
+
+        # Phase 1: ramp steering to target
+        x_st_1 = odeint(func_ST, x0, t1, args=([v_delta, 0.0], p_st))
+        x_stp_1 = odeint(func_STP, x0, t1, args=([v_delta, 0.0], p_stp))
+
+        # Phase 2: hold steering, let yaw rate settle
+        x_st_2 = odeint(func_ST, x_st_1[-1], t2, args=([0.0, 0.0], p_st))
+        x_stp_2 = odeint(func_STP, x_stp_1[-1], t2, args=([0.0, 0.0], p_stp))
+
+        psi_dot_ss_st.append(x_st_2[-1, 5])
+        psi_dot_ss_stp.append(x_stp_2[-1, 5])
+
+    _, ax = plt.subplots(figsize=(7, 5))
+    ax.plot(delta_targets, psi_dot_ss_st, "o-")
+    ax.plot(delta_targets, psi_dot_ss_stp, "o-")
+    ax.set_xlabel("steady-state delta [rad]")
+    ax.set_ylabel("steady-state psi_dot [rad/s]")
+    ax.set_title(f"Understeer sweep  (vel0={vel0})")
+    ax.legend(["ST", "STP"])
+    ax.grid(True)
+    plt.tight_layout()
+    plt.show()
+
+
+def compare_low_speed_blend():
+    """Low speed accelerating through the kinematic blend region.
+
+    ST hard-switches at V < 0.5; STP tanh-blends around v_s = 0.2. The longitudinal
+    acceleration drives V from 0.15 across both thresholds during the run.
+    """
+    vel0 = 0.15
+    v_delta = 0.2
+    a_long = 0.3
+    tFinal = 2.0
+
+    t = np.arange(0, tFinal, 0.01)
+    u = [v_delta, a_long]
+    x0 = _initial_state(vel0)
+
+    x_st = odeint(func_ST, x0, t, args=(u, p_st))
+    x_stp = odeint(func_STP, x0, t, args=(u, p_stp))
+
+    _plot_pair(t, x_st, x_stp, f"Low-speed kinematic blend  (vel0={vel0}, accl={a_long})")
+
+
+if __name__ == "__main__":
+    compare_linear_cornering()
+    compare_saturation_cornering()
+    compare_understeer_sweep()
+    compare_low_speed_blend()

--- a/examples/analysis/model_validation/test_stp_smoke.py
+++ b/examples/analysis/model_validation/test_stp_smoke.py
@@ -1,0 +1,104 @@
+"""Manual smoke checks for the STP (Single Track Pacejka) dynamics model.
+
+Wiring + short rollouts in straight-line, moderate-cornering, and
+hard-cornering regimes. Correctness against a reference is in
+``test_stp_validation.py`` (same folder).
+
+Run from the gymkhana root with the project's venv:
+    python examples/analysis/model_validation/test_stp_smoke.py
+"""
+
+import numpy as np
+
+from gymkhana.envs.dynamic_models import DynamicModel
+from gymkhana.envs.integrator import RK4Integrator
+from gymkhana.envs.params import load_params
+
+
+def smoke_construction(model, params):
+    print("\n=== construction & wiring ===")
+    print(f"  enum:               {model}")
+    print(f"  f_dynamics:         {model.f_dynamics.__name__}")
+    print(f"  standardized fn:    {model.get_standardized_state_fn().__name__}")
+    print(f"  params loaded:      {len(params)} keys")
+    x0 = model.get_initial_state(pose=np.array([0.0, 0.0, 0.0]), params=params)
+    assert x0.shape == (7,), f"expected (7,), got {x0.shape}"
+    print(f"  x0 shape:           {x0.shape}  [OK]")
+
+
+def smoke_dynamics_at_rest(model, params):
+    print("\n=== single-step finiteness at rest ===")
+    x0 = model.get_initial_state(pose=np.array([0.0, 0.0, 0.0]), params=params)
+    u = np.array([0.0, 1.0])  # zero steer-vel, +1 m/s^2 accel
+    xdot = model.f_dynamics(x0, u, params)
+    assert xdot.shape == (7,)
+    assert np.all(np.isfinite(xdot)), "non-finite derivative at rest"
+    print(f"  xdot at rest:       {xdot}  [OK]")
+
+
+def smoke_straight_line(model, params, integ):
+    """V0=1 (above blend) + accel=1 for 2 s -> V≈3, no lateral drift."""
+    print("\n=== straight-line acceleration ===")
+    x = np.zeros(7)
+    x[3] = 1.0
+    u = np.array([0.0, 1.0])
+    dt = 0.01
+    for _ in range(200):
+        x = integ.integrate(model.f_dynamics, x, u, dt, params)
+
+    print(f"  after 2 s straight + accel=1: V={x[3]:.3f}, X={x[0]:.3f}, Y={x[1]:.3e}, β={x[6]:.3e}")
+    assert np.all(np.isfinite(x))
+    assert 2.99 < x[3] < 3.01, f"unexpected V: {x[3]}"
+    assert abs(x[1]) < 1e-6, f"unexpected lateral drift Y: {x[1]}"
+    assert abs(x[6]) < 1e-9, f"slip angle should be zero on straight line: {x[6]}"
+    print("  [OK]")
+
+
+def smoke_moderate_cornering(model, params, integ):
+    """V0=3, ramp δ to ~0.1 rad, hold 1 s. Expect ψ̇>0 and bounded β."""
+    print("\n=== moderate cornering ===")
+    dt = 0.01
+    x = np.zeros(7)
+    x[3] = 3.0
+    for _ in range(5):
+        x = integ.integrate(model.f_dynamics, x, np.array([2.0, 0.0]), dt, params)
+    print(f"  after 0.05 s steer ramp:   δ={x[2]:.3f}, ψ̇={x[5]:.3f}, β={x[6]:.3f}")
+    for _ in range(100):
+        x = integ.integrate(model.f_dynamics, x, np.array([0.0, 0.0]), dt, params)
+    print(f"  after 1.05 s cornering:    ψ̇={x[5]:.3f} rad/s, β={x[6]:.3f}, V={x[3]:.3f}")
+
+    assert np.all(np.isfinite(x))
+    assert x[5] > 0, f"expected positive yaw rate for positive steer, got {x[5]}"
+    assert abs(x[6]) < np.pi / 4, f"slip angle out of reasonable range: {x[6]}"
+    assert params["s_min"] <= x[2] <= params["s_max"], f"steering out of limits: {x[2]}"
+    print("  [OK]")
+
+
+def smoke_hard_cornering(model, params, integ):
+    """δ=0.4 pre-loaded at V=6 for 1 s. Pacejka should saturate without diverging."""
+    print("\n=== hard cornering (saturation) ===")
+    dt = 0.01
+    x = np.zeros(7)
+    x[2] = 0.4
+    x[3] = 6.0
+    for _ in range(100):
+        x = integ.integrate(model.f_dynamics, x, np.array([0.0, 0.0]), dt, params)
+    print(f"  hard corner (δ=0.4 @ 6 m/s, 1 s): ψ̇={x[5]:.3f}, β={x[6]:.3f}")
+    assert np.all(np.isfinite(x)), "Pacejka rollout went non-finite"
+    assert abs(x[5]) < 50.0, f"yaw rate exploded: {x[5]}"
+    assert abs(x[6]) < np.pi / 2, f"slip angle past pi/2: {x[6]}"
+    print("  [OK]")
+
+
+if __name__ == "__main__":
+    model = DynamicModel.from_string("stp")
+    params = load_params("f1tenth_stp")
+    integ = RK4Integrator()
+
+    smoke_construction(model, params)
+    smoke_dynamics_at_rest(model, params)
+    smoke_straight_line(model, params, integ)
+    smoke_moderate_cornering(model, params, integ)
+    smoke_hard_cornering(model, params, integ)
+
+    print("\nAll smoke checks passed.")

--- a/examples/analysis/model_validation/test_stp_validation.py
+++ b/examples/analysis/model_validation/test_stp_validation.py
@@ -1,0 +1,438 @@
+"""Manual validation script for the STP dynamics model.
+
+Independent checks, run for inspection (prints + plots, with assertions):
+    1.  Parity vs. a Python port of f110's STDKinematics::update_pacejka in the
+        dynamic regime (V=5 m/s, blend ≈ 1 in both formulations). Tests the
+        math line-by-line.
+    1b. Same parity check at low speed (V=0.1 m/s) with gymkhana's blend
+        thresholds forced to match f110's. Exercises the kinematic-blend
+        branch — ψ̇ excluded by design (semantic difference; see docstring).
+    2.  Steady-state cornering radius matches the analytical understeer-
+        gradient prediction at small slip across V ∈ {1, 2, 3} m/s.
+    3.  Pacejka lateral-force curve has the expected shape (rises, peaks,
+        falls) and the right peak magnitude.
+
+Run from the gymkhana root with the project venv:
+    python examples/analysis/model_validation/test_stp_validation.py
+"""
+
+import numpy as np
+
+from gymkhana.envs.dynamic_models.single_track_pacejka.single_track_pacejka import vehicle_dynamics_stp
+from gymkhana.envs.integrator import EulerIntegrator, RK4Integrator
+from gymkhana.envs.params import load_params
+
+PLOT = True
+
+
+# -----------------------------------------------------------------------------
+# Reference: faithful Python port of f110's STDKinematics::update_pacejka.
+# Mirrors std_kinematics.cpp:14-133 line by line. Uses Euler integration and
+# the f110 blend thresholds (v_b=3, v_s=1).
+# -----------------------------------------------------------------------------
+def f110_pacejka_step(state, accel, steer_angle_vel, p, dt, blend_v_b=3.0, blend_v_s=1.0):
+    g = 9.81
+    v_min = blend_v_b - 2 * blend_v_s
+
+    # Slip angles
+    if state["v_x"] >= v_min:
+        alpha_f = np.arctan2(-state["v_y"] - p["lf"] * state["w"], state["v_x"]) + state["delta"]
+        alpha_r = np.arctan2(-state["v_y"] + p["lr"] * state["w"], state["v_x"])
+    else:
+        alpha_f = 0.0
+        alpha_r = 0.0
+
+    F_zf = p["m"] * (-accel * p["h_s"] + g * p["lr"]) / (p["lf"] + p["lr"])
+    F_zr = p["m"] * (accel * p["h_s"] + g * p["lf"]) / (p["lf"] + p["lr"])
+    F_yf = (
+        p["mu"]
+        * p["D_f"]
+        * F_zf
+        * np.sin(
+            p["C_f"] * np.arctan(p["B_f"] * alpha_f - p["E_f"] * (p["B_f"] * alpha_f - np.arctan(p["B_f"] * alpha_f)))
+        )
+    )
+    F_yr = (
+        p["mu"]
+        * p["D_r"]
+        * F_zr
+        * np.sin(
+            p["C_r"] * np.arctan(p["B_r"] * alpha_r - p["E_r"] * (p["B_r"] * alpha_r - np.arctan(p["B_r"] * alpha_r)))
+        )
+    )
+
+    x_dot = state["v_x"] * np.cos(state["theta"]) - state["v_y"] * np.sin(state["theta"])
+    y_dot = state["v_x"] * np.sin(state["theta"]) + state["v_y"] * np.cos(state["theta"])
+    vx_dot = accel + (1 / p["m"]) * (-F_yf * np.sin(state["delta"])) + state["v_y"] * state["w"]
+    vy_dot = (1 / p["m"]) * (F_yr + F_yf * np.cos(state["delta"])) - state["v_x"] * state["w"]
+    w_dot = (1 / p["I_z"]) * (-F_yr * p["lr"] + F_yf * p["lf"] * np.cos(state["delta"]))
+
+    end = {
+        "x": state["x"] + x_dot * dt,
+        "y": state["y"] + y_dot * dt,
+        "theta": state["theta"] + state["w"] * dt,
+        "v_x": state["v_x"] + vx_dot * dt,
+        "v_y": state["v_y"] + vy_dot * dt,
+        "delta": state["delta"] + steer_angle_vel * dt,
+        "w": state["w"] + w_dot * dt,
+    }
+
+    # Kinematic update (f110 update_k, integrates slip_angle separately)
+    lwb = p["lf"] + p["lr"]
+    theta_dot_k = state["v_x"] * np.tan(state["delta"]) / lwb
+    end_kin_v_x = state["v_x"] + accel * dt
+    end_kin_delta = state["delta"] + steer_angle_vel * dt
+    # v_y from slip-angle integration (kinematic)
+    slip = np.arctan2(state["v_y"], state["v_x"]) if state["v_x"] != 0 else 0.0
+    slip_dot = (
+        (1 / (1 + ((p["lr"] / lwb) * np.tan(state["delta"])) ** 2))
+        * (p["lr"] / (lwb * np.cos(state["delta"]) ** 2))
+        * steer_angle_vel
+    )
+    end_kin = {
+        "x": state["x"] + (state["v_x"] * np.cos(state["theta"]) - state["v_y"] * np.sin(state["theta"])) * dt,
+        "y": state["y"] + (state["v_x"] * np.sin(state["theta"]) + state["v_y"] * np.cos(state["theta"])) * dt,
+        "theta": state["theta"] + theta_dot_k * dt,
+        "v_x": end_kin_v_x,
+        "delta": end_kin_delta,
+        "w": state["w"],  # carried
+    }
+    end_kin["v_y"] = np.tan(slip + slip_dot * dt) * end_kin_v_x
+
+    # Blend
+    w_std = 0.5 * (1 + np.tanh((state["v_x"] - blend_v_b) / blend_v_s))
+    if state["v_x"] < v_min:
+        w_std = 0.0
+    w_kin = 1.0 - w_std
+    blended = {}
+    for k in ("x", "y", "theta", "v_x", "v_y", "delta", "w"):
+        blended[k] = w_std * end[k] + w_kin * end_kin[k]
+    return blended
+
+
+def stp_state_to_f110(x):
+    """gymkhana 7-state -> f110 dict (v_x = V cos beta, v_y = V sin beta)."""
+    return {
+        "x": x[0],
+        "y": x[1],
+        "delta": x[2],
+        "v_x": x[3] * np.cos(x[6]),
+        "v_y": x[3] * np.sin(x[6]),
+        "theta": x[4],
+        "w": x[5],
+    }
+
+
+def f110_state_to_stp(s):
+    V = np.hypot(s["v_x"], s["v_y"])
+    beta = np.arctan2(s["v_y"], s["v_x"]) if V > 1e-9 else 0.0
+    return np.array([s["x"], s["y"], s["delta"], V, s["theta"], s["w"], beta])
+
+
+# -----------------------------------------------------------------------------
+# Test 1 — parity with f110 reference at high V (where blend ≈ 1 in both)
+# -----------------------------------------------------------------------------
+def test_parity_with_f110_reference():
+    print("\n=== Test 1: parity with f110 update_pacejka reference ===")
+    params = load_params("f1tenth_stp")
+
+    # Initial state at V=5 m/s, no slip, no steering — well above both blend
+    # transitions so w_std ≈ 1 in both formulations.
+    x_stp = np.array([0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0])
+    s_ref = stp_state_to_f110(x_stp)
+
+    # Step the steering up gradually to produce non-trivial dynamics.
+    dt = 0.001  # small dt so Euler error is small
+    n_steps = 500  # 0.5 s
+    integ = EulerIntegrator()
+
+    # Override gymkhana blend thresholds in-place to match f110 for parity.
+    # We'll do this by patching the function-local v_s, v_b at runtime:
+    # easiest is to monkey-patch by passing through a wrapper that runs above
+    # both transitions where the blend is irrelevant. V starts at 5 m/s, so
+    # both blends are saturated to w_std = 1.
+
+    t_hist = np.zeros(n_steps + 1)
+    stp_hist = np.zeros((n_steps + 1, 7))
+    ref_hist = np.zeros((n_steps + 1, 7))
+    stp_hist[0] = x_stp
+    ref_hist[0] = f110_state_to_stp(s_ref)
+
+    for k in range(n_steps):
+        # Steering velocity ramp: 1 rad/s for first 50 ms (-> delta=0.05), then hold
+        sv = 1.0 if k < 50 else 0.0
+        accel = 0.0
+        u = np.array([sv, accel])
+        x_stp = integ.integrate(vehicle_dynamics_stp, x_stp, u, dt, params)
+        s_ref = f110_pacejka_step(s_ref, accel, sv, params, dt)
+        t_hist[k + 1] = (k + 1) * dt
+        stp_hist[k + 1] = x_stp
+        ref_hist[k + 1] = f110_state_to_stp(s_ref)
+
+    err_hist = np.abs(stp_hist - ref_hist)
+    max_err = err_hist.max(axis=0)
+
+    print("  max abs error per state component over rollout (state order [x,y,δ,V,ψ,ψ̇,β]):")
+    print(f"    {max_err}")
+    # In the dynamic regime (w_std ≈ 1 in both) and small dt, the only sources
+    # of disagreement are the chain-rule integration order (gymkhana integrates
+    # V, β; f110 integrates v_x, v_y) and the kinematic-blend definitions. At
+    # V=5 with w_std≈1, both should match to O(dt²) — i.e. ~1e-3 over 0.5 s.
+    tol = 5e-3
+    assert np.all(max_err < tol), f"parity exceeded {tol}: {max_err}"
+    print(f"  [OK] all components within {tol}")
+
+    if PLOT:
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(2, 3, figsize=(13, 7))
+
+        axes[0, 0].plot(stp_hist[:, 0], stp_hist[:, 1], label="STP")
+        axes[0, 0].plot(ref_hist[:, 0], ref_hist[:, 1], "--", label="f110 ref")
+        axes[0, 0].set_title("trajectory (X, Y)")
+        axes[0, 0].set_xlabel("X [m]")
+        axes[0, 0].set_ylabel("Y [m]")
+        axes[0, 0].set_aspect("equal")
+        axes[0, 0].legend()
+
+        for ax, idx, name in [
+            (axes[0, 1], 3, "V [m/s]"),
+            (axes[0, 2], 6, "β [rad]"),
+            (axes[1, 0], 5, "ψ̇ [rad/s]"),
+            (axes[1, 1], 2, "δ [rad]"),
+        ]:
+            ax.plot(t_hist, stp_hist[:, idx], label="STP")
+            ax.plot(t_hist, ref_hist[:, idx], "--", label="f110 ref")
+            ax.set_title(name)
+            ax.set_xlabel("t [s]")
+            ax.legend()
+
+        ax = axes[1, 2]
+        labels = ["x", "y", "δ", "V", "ψ", "ψ̇", "β"]
+        for idx, name in enumerate(labels):
+            ax.semilogy(t_hist, err_hist[:, idx] + 1e-15, label=name)
+        ax.axhline(tol, color="k", ls=":", label=f"tol={tol}")
+        ax.set_title("|STP − f110 ref|")
+        ax.set_xlabel("t [s]")
+        ax.legend(fontsize=8, ncol=2)
+
+        fig.suptitle("Test 1: STP vs f110 reference parity")
+        plt.tight_layout()
+        plt.show()
+
+
+# -----------------------------------------------------------------------------
+# Test 1b — parity at low speed where the kinematic blend dominates
+# -----------------------------------------------------------------------------
+def test_parity_with_f110_reference_low_speed():
+    """Below v_min in both formulations, both reduce to the bicycle kinematic model.
+
+    Forces gymkhana's blend thresholds to match f110's via params overrides
+    (blend_v_s=3.0, blend_v_b=1.0, blend_v_min=1.0). With V well under v_min,
+    f110's hard cutoff sets w_std=0 exactly while gymkhana's tanh evaluates to
+    ~0.3% — the residual dynamic contribution uses α=0, β_dot=0, so its
+    body-frame derivatives reduce to v_x_dot=ACCL, v_y_dot=0.
+
+    Excluded from the parity bound: ψ̇ (state index 5). Gymkhana's blend keeps
+    the yaw-rate state kinematically consistent at low speed (psi_ddot_ks
+    propagates ψ̇ as the derivative of V·tan(δ)/L), while f110's kinematic
+    branch carries ``w`` unchanged. This is a deliberate design difference,
+    not a math error. The check below verifies (a) yaw *angle* ψ still agrees
+    (both integrate via V·tan(δ)/L), and (b) gymkhana's ψ̇ tracks the
+    expected kinematic value V·tan(δ)/L.
+    """
+    print("\n=== Test 1b: low-speed parity with f110 reference ===")
+    base = load_params("f1tenth_stp")
+    # f110 thresholds: v_b=3 (blend center), v_s=1 (sharpness), v_min=1 (hard cutoff).
+    # In gymkhana's variable naming these map to blend_v_s, blend_v_b, blend_v_min.
+    params = {**base, "blend_v_s": 3.0, "blend_v_b": 1.0, "blend_v_min": 1.0}
+
+    x_stp = np.array([0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0])  # V0=0.1 m/s
+    s_ref = stp_state_to_f110(x_stp)
+
+    dt = 1e-3
+    n_steps = 500  # 0.5 s; with accel=0.3 we end at V≈0.25, still well under v_min=1.
+    integ = EulerIntegrator()
+
+    t_hist = np.zeros(n_steps + 1)
+    stp_hist = np.zeros((n_steps + 1, 7))
+    ref_hist = np.zeros((n_steps + 1, 7))
+    stp_hist[0] = x_stp
+    ref_hist[0] = f110_state_to_stp(s_ref)
+
+    for k in range(n_steps):
+        sv = 0.5 if k < 100 else 0.0  # 0.1 s steering ramp -> δ ≈ 0.05 rad
+        accel = 0.3
+        u = np.array([sv, accel])
+        x_stp = integ.integrate(vehicle_dynamics_stp, x_stp, u, dt, params)
+        s_ref = f110_pacejka_step(s_ref, accel, sv, params, dt, blend_v_b=3.0, blend_v_s=1.0)
+        t_hist[k + 1] = (k + 1) * dt
+        stp_hist[k + 1] = x_stp
+        ref_hist[k + 1] = f110_state_to_stp(s_ref)
+
+    err_hist = np.abs(stp_hist - ref_hist)
+    max_err = err_hist.max(axis=0)
+    print("  max abs error per state component over rollout (state order [x,y,δ,V,ψ,ψ̇,β]):")
+    print(f"    {max_err}")
+    tol = 5e-3
+    parity_idx = [0, 1, 2, 3, 4, 6]  # all except ψ̇ (see docstring)
+    assert np.all(max_err[parity_idx] < tol), f"low-speed parity exceeded {tol}: {max_err}"
+    print(f"  [OK] [x,y,δ,V,ψ,β] all within {tol}")
+
+    # Positive correctness check on gymkhana ψ̇: should track V·tan(δ)/L.
+    L = params["lf"] + params["lr"]
+    psi_dot_kin = stp_hist[:, 3] * np.tan(stp_hist[:, 2]) / L
+    psi_dot_err = np.abs(stp_hist[:, 5] - psi_dot_kin).max()
+    assert psi_dot_err < 1e-3, f"gymkhana ψ̇ drifts from V·tan(δ)/L: {psi_dot_err}"
+    print(f"  [OK] gymkhana ψ̇ tracks V·tan(δ)/L within {psi_dot_err:.2e}")
+
+    if PLOT:
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(2, 3, figsize=(13, 7))
+        axes[0, 0].plot(stp_hist[:, 0], stp_hist[:, 1], label="STP")
+        axes[0, 0].plot(ref_hist[:, 0], ref_hist[:, 1], "--", label="f110 ref")
+        axes[0, 0].set_title("trajectory (X, Y)")
+        axes[0, 0].set_aspect("equal")
+        axes[0, 0].legend()
+        for ax, idx, name in [
+            (axes[0, 1], 3, "V [m/s]"),
+            (axes[0, 2], 6, "β [rad]"),
+            (axes[1, 0], 5, "ψ̇ [rad/s]"),
+            (axes[1, 1], 2, "δ [rad]"),
+        ]:
+            ax.plot(t_hist, stp_hist[:, idx], label="STP")
+            ax.plot(t_hist, ref_hist[:, idx], "--", label="f110 ref")
+            ax.set_title(name)
+            ax.set_xlabel("t [s]")
+            ax.legend()
+        ax = axes[1, 2]
+        labels = ["x", "y", "δ", "V", "ψ", "ψ̇", "β"]
+        for idx, name in enumerate(labels):
+            ax.semilogy(t_hist, err_hist[:, idx] + 1e-15, label=name)
+        ax.axhline(tol, color="k", ls=":", label=f"tol={tol}")
+        ax.set_title("|STP − f110 ref|")
+        ax.set_xlabel("t [s]")
+        ax.legend(fontsize=8, ncol=2)
+        fig.suptitle("Test 1b: low-speed parity (V<v_min, kinematic dominates)")
+        plt.tight_layout()
+        plt.show()
+
+
+# -----------------------------------------------------------------------------
+# Test 2 — steady-state radius matches the analytical understeer-gradient prediction
+# -----------------------------------------------------------------------------
+def test_steady_state_cornering():
+    """Steady-state radius ≈ (L + K_us·V²/g) / tan(δ).
+
+    K_us = (m·g/L) · (lr/C_αf − lf/C_αr), where the small-slip cornering
+    stiffnesses are C_α = μ·D·C·B·F_z (derivative of the Pacejka curve at α=0).
+    Replaces the prior "within 50% of Ackermann" bound with a true linearised
+    prediction that should hold to a few percent in the small-slip regime.
+    Sweeps three operating points to catch direction-of-deviation regressions.
+    """
+    print("\n=== Test 2: steady-state cornering vs understeer-gradient prediction ===")
+    params = load_params("f1tenth_stp")
+    integ = RK4Integrator()
+    dt = 0.005
+    g = 9.81
+
+    L = params["lf"] + params["lr"]
+    F_zf_static = params["m"] * g * params["lr"] / L
+    F_zr_static = params["m"] * g * params["lf"] / L
+    mu = params["mu"]
+    C_af = mu * params["D_f"] * params["C_f"] * params["B_f"] * F_zf_static
+    C_ar = mu * params["D_r"] * params["C_r"] * params["B_r"] * F_zr_static
+    K_us = (params["m"] * g / L) * (params["lr"] / C_af - params["lf"] / C_ar)
+    print(f"  L={L:.3f} m, C_αf={C_af:.1f} N/rad, C_αr={C_ar:.1f} N/rad, K_us={K_us:.4f} rad")
+
+    delta_target = 0.05
+    cases = [(1.0, "linear-tire"), (2.0, "mild understeer"), (3.0, "moderate understeer")]
+    settle_t = 5.0
+    n_steps = int(settle_t / dt)
+    tol = 0.05  # 5% — small-slip linearisation should be tight at δ=0.05.
+
+    for V0, label in cases:
+        x = np.zeros(7)
+        x[2] = delta_target
+        x[3] = V0
+        for _ in range(n_steps):
+            x = integ.integrate(vehicle_dynamics_stp, x, np.array([0.0, 0.0]), dt, params)
+
+        psi_dot_ss = x[5]
+        V_ss = x[3]
+        radius_actual = V_ss / psi_dot_ss
+        radius_predicted = (L + K_us * V_ss**2 / g) / np.tan(delta_target)
+        rel_err = abs(radius_actual - radius_predicted) / radius_predicted
+        print(
+            f"  V0={V0} ({label}): V_ss={V_ss:.3f}, R_actual={radius_actual:.3f} m, "
+            f"R_predicted={radius_predicted:.3f} m, rel_err={rel_err * 100:.2f}%"
+        )
+        assert rel_err < tol, f"V0={V0}: radius off by {rel_err * 100:.1f}% (tol {tol * 100:.0f}%)"
+    print(f"  [OK] all cases within {tol * 100:.0f}% of understeer-gradient prediction")
+
+
+# -----------------------------------------------------------------------------
+# Test 3 — Pacejka tire force curve has the right shape
+# -----------------------------------------------------------------------------
+def test_tire_force_curve():
+    """Pacejka curve: rises ~linearly near α=0, peaks, falls off."""
+    print("\n=== Test 3: Pacejka lateral-force curve shape ===")
+    params = load_params("f1tenth_stp")
+    g = 9.81
+    F_zf = params["m"] * g * params["lr"] / (params["lf"] + params["lr"])
+    Bf, Cf, Df, Ef, mu = params["B_f"], params["C_f"], params["D_f"], params["E_f"], params["mu"]
+
+    alphas = np.linspace(-0.5, 0.5, 201)
+    Fy = mu * Df * F_zf * np.sin(Cf * np.arctan(Bf * alphas - Ef * (Bf * alphas - np.arctan(Bf * alphas))))
+
+    # Slope at origin should be positive (linear stiffness)
+    slope0 = (Fy[101] - Fy[99]) / (alphas[101] - alphas[99])
+    assert slope0 > 0, f"unexpected slope at α=0: {slope0}"
+    # Curve should peak somewhere in (0, 0.5)
+    pos_idx = np.argmax(Fy)
+    pos_alpha_peak = alphas[pos_idx]
+    pos_peak = Fy[pos_idx]
+    assert 0.05 < pos_alpha_peak < 0.4, f"peak at α={pos_alpha_peak:.3f} outside expected range"
+    # Symmetric (odd function)
+    assert np.allclose(Fy, -Fy[::-1], atol=1e-9)
+    # Peak ≈ μ·D·F_z
+    expected_peak = mu * Df * F_zf
+    assert abs(pos_peak - expected_peak) / expected_peak < 0.02
+    print(
+        f"  front: peak F_y = {pos_peak:.2f} N at α = {pos_alpha_peak:.3f} rad "
+        f"(expected ≈ {expected_peak:.2f} N at peak)"
+    )
+    print(f"  slope at α=0: {slope0:.1f} N/rad (linear stiffness Bf·Cf·Df·F_z·μ = {Bf * Cf * Df * F_zf * mu:.1f})")
+    print("  [OK] curve is odd, slope > 0 at origin, peaks in valid range")
+
+    if PLOT:
+        import matplotlib.pyplot as plt
+
+        # Also compute rear curve for the plot
+        F_zr = params["m"] * g * params["lf"] / (params["lf"] + params["lr"])
+        Br, Cr, Dr, Er = params["B_r"], params["C_r"], params["D_r"], params["E_r"]
+        Fy_r = mu * Dr * F_zr * np.sin(Cr * np.arctan(Br * alphas - Er * (Br * alphas - np.arctan(Br * alphas))))
+
+        _, ax = plt.subplots(figsize=(8, 5))
+        ax.plot(alphas, Fy, label=f"front (peak {pos_peak:.1f} N @ α={pos_alpha_peak:.2f})")
+        ax.plot(alphas, Fy_r, label=f"rear (peak {Fy_r.max():.1f} N @ α={alphas[np.argmax(Fy_r)]:.2f})")
+        ax.axhline(mu * Df * F_zf, color="C0", ls=":", alpha=0.5)
+        ax.axhline(mu * Dr * F_zr, color="C1", ls=":", alpha=0.5)
+        ax.axhline(0, color="k", lw=0.5)
+        ax.axvline(0, color="k", lw=0.5)
+        ax.set_xlabel("slip angle α [rad]")
+        ax.set_ylabel("F_y [N]")
+        ax.set_title("Test 3: Pacejka lateral force curves (steady-state load)")
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        plt.show()
+
+
+if __name__ == "__main__":
+    test_parity_with_f110_reference()
+    test_parity_with_f110_reference_low_speed()
+    test_steady_state_cornering()
+    test_tire_force_curve()
+    print("\nAll validation tests passed.")

--- a/examples/analysis/traj_compare.py
+++ b/examples/analysis/traj_compare.py
@@ -8,6 +8,7 @@ Usage:
     python examples/analysis/traj_compare.py --path /path/to/bag_100Hz.npz --model ks
     python examples/analysis/traj_compare.py --path /path/to/bag_100Hz.npz --model st
     python examples/analysis/traj_compare.py --path /path/to/bag_100Hz.npz --model std
+    python examples/analysis/traj_compare.py --path /path/to/bag_100Hz.npz --model stp
 
 Output:
     figures/analysis/traj_compare/<bag_stem>/plt_<model>.png
@@ -31,7 +32,7 @@ from gymkhana.envs.gymkhana_env import GKEnv
 def main():
     parser = argparse.ArgumentParser(description="Sim2Real trajectory comparison")
     parser.add_argument("--path", required=True, help="Path to 100Hz resampled NPZ file")
-    parser.add_argument("--model", required=True, choices=["ks", "st", "std"], help="Vehicle dynamics model")
+    parser.add_argument("--model", required=True, choices=["ks", "st", "std", "stp"], help="Vehicle dynamics model")
     args = parser.parse_args()
 
     # Load real data
@@ -43,6 +44,7 @@ def main():
     vicon_y = data["vicon_y"]
     vicon_yaw = data["vicon_yaw"]
     vicon_body_vx = data["vicon_body_vx"]
+    vicon_body_vy = data["vicon_body_vy"]
     vicon_r = data["vicon_r"]
 
     # Output path
@@ -54,6 +56,8 @@ def main():
     # Select params based on model
     if args.model == "std":
         params = GKEnv.f1tenth_std_vehicle_params()
+    elif args.model == "stp":
+        params = GKEnv.f1tenth_stp_vehicle_params()
     else:
         params = GKEnv.f1tenth_vehicle_params()
 
@@ -77,8 +81,10 @@ def main():
     sim_x = [float(agent_obs["pose_x"])]
     sim_y = [float(agent_obs["pose_y"])]
     sim_vx = [float(agent_obs["linear_vel_x"])]
+    sim_vy = [float(agent_obs["linear_vel_y"])]
     sim_delta = [float(agent_obs["delta"])]
     sim_yaw_rate = [float(agent_obs["ang_vel_z"])]
+    sim_beta = [float(agent_obs["beta"])]
     sim_cmd_speed = [cmd_speed[0]]
     sim_cmd_steer = [cmd_steer[0]]
 
@@ -91,8 +97,10 @@ def main():
         sim_x.append(float(agent_obs["pose_x"]))
         sim_y.append(float(agent_obs["pose_y"]))
         sim_vx.append(float(agent_obs["linear_vel_x"]))
+        sim_vy.append(float(agent_obs["linear_vel_y"]))
         sim_delta.append(float(agent_obs["delta"]))
         sim_yaw_rate.append(float(agent_obs["ang_vel_z"]))
+        sim_beta.append(float(agent_obs["beta"]))
         sim_cmd_speed.append(cmd_speed[i])
         sim_cmd_steer.append(cmd_steer[i])
 
@@ -102,8 +110,10 @@ def main():
     sim_x = np.array(sim_x)
     sim_y = np.array(sim_y)
     sim_vx = np.array(sim_vx)
+    sim_vy = np.array(sim_vy)
     sim_delta = np.array(sim_delta)
     sim_yaw_rate = np.array(sim_yaw_rate)
+    sim_beta = np.array(sim_beta)
     sim_cmd_speed = np.array(sim_cmd_speed)
     sim_cmd_steer = np.array(sim_cmd_steer)
 
@@ -126,8 +136,23 @@ def main():
     real_accl = np.gradient(savgol_filter(vicon_body_vx, window_length=21, polyorder=2), t)
     sim_accl = np.gradient(savgol_filter(sim_vx, window_length=11, polyorder=2), sim_t)
 
-    fig, axes = plt.subplots(1, 5, figsize=(40, 7))
+    # Real slip angle from body-frame Vicon velocities, masked at low speed
+    real_speed = np.hypot(vicon_body_vx, vicon_body_vy)
+    real_beta = np.arctan2(vicon_body_vy, vicon_body_vx)
+    real_beta = np.where(real_speed > 0.2, real_beta, np.nan)
+
+    fig, axes_grid = plt.subplots(2, 4, figsize=(32, 14))
     fig.suptitle(f"Sim2Real Comparison — {model_label} model ({stem})", fontsize=14)
+    axes_grid[0, 3].axis("off")
+    axes = [
+        axes_grid[0, 0],  # XY
+        axes_grid[0, 1],  # vx
+        axes_grid[0, 2],  # vy
+        axes_grid[1, 0],  # steering
+        axes_grid[1, 1],  # yaw rate
+        axes_grid[1, 2],  # long. accel
+        axes_grid[1, 3],  # slip angle
+    ]
 
     # --- Plot 1: XY Trajectory ---
     ax = axes[0]
@@ -141,20 +166,30 @@ def main():
     ax.legend()
     ax.grid(True, alpha=0.3)
 
-    # --- Plot 2: Velocity ---
+    # --- Plot 2: Longitudinal velocity (vx) ---
     ax = axes[1]
     ax.plot(t[:n_real], cmd_speed[:n_real], label="Commanded speed", linewidth=1, alpha=0.7)
-    ax.plot(t[:n_real], vicon_body_vx[:n_real], label="Real velocity (Vicon)", linewidth=1)
+    ax.plot(t[:n_real], vicon_body_vx[:n_real], label="Real vx (Vicon)", linewidth=1)
     ax.plot(sim_t[:n_real], sim_cmd_speed[:n_real], label="Sim commanded speed", linewidth=1, linestyle="--")
-    ax.plot(sim_t[:n_real], sim_vx[:n_real], label="Sim actual velocity", linewidth=1.5)
+    ax.plot(sim_t[:n_real], sim_vx[:n_real], label="Sim vx", linewidth=1.5)
     ax.set_xlabel("Time (s)")
     ax.set_ylabel("Velocity (m/s)")
-    ax.set_title("Velocity — Command vs Actual")
+    ax.set_title("Longitudinal Velocity (vx) — Command vs Actual")
     ax.legend()
     ax.grid(True, alpha=0.3)
 
-    # --- Plot 3: Steering ---
+    # --- Plot 3: Lateral velocity (vy) ---
     ax = axes[2]
+    ax.plot(t[:n_real], vicon_body_vy[:n_real], label="Real vy (Vicon)", linewidth=1)
+    ax.plot(sim_t[:n_real], sim_vy[:n_real], label=f"Sim vy ({model_label})", linewidth=1.5, linestyle="--")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Velocity (m/s)")
+    ax.set_title("Lateral Velocity (vy) — Real vs Sim")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # --- Plot 4: Steering ---
+    ax = axes[3]
     ax.plot(t[:n_real], cmd_steer[:n_real], label="Commanded steering", linewidth=1, alpha=0.7)
     ax.plot(sim_t[:n_real], sim_cmd_steer[:n_real], label="Sim commanded steering", linewidth=1, linestyle="--")
     ax.plot(sim_t[:n_real], sim_delta[:n_real], label="Sim actual delta", linewidth=1.5)
@@ -164,8 +199,8 @@ def main():
     ax.legend()
     ax.grid(True, alpha=0.3)
 
-    # --- Plot 4: Yaw rate ---
-    ax = axes[3]
+    # --- Plot 5: Yaw rate ---
+    ax = axes[4]
     ax.plot(t[:n_real], vicon_r[:n_real], label="Real yaw rate (Vicon)", linewidth=1)
     ax.plot(sim_t[:n_real], sim_yaw_rate[:n_real], label=f"Sim yaw rate ({model_label})", linewidth=1.5, linestyle="--")
     ax.set_xlabel("Time (s)")
@@ -174,8 +209,8 @@ def main():
     ax.legend()
     ax.grid(True, alpha=0.3)
 
-    # --- Plot 5: Longitudinal acceleration ---
-    ax = axes[4]
+    # --- Plot 6: Longitudinal acceleration ---
+    ax = axes[5]
     ax.plot(t[:n_real], real_accl[:n_real], label="Real dv/dt (Vicon)", linewidth=1)
     ax.plot(sim_t[:n_real], sim_accl[:n_real], label=f"Sim dv/dt ({model_label})", linewidth=1.5, linestyle="--")
     ax.axhline(params["a_max"], color="red", linewidth=0.5, linestyle=":", label="±a_max")
@@ -183,6 +218,16 @@ def main():
     ax.set_xlabel("Time (s)")
     ax.set_ylabel("Acceleration (m/s²)")
     ax.set_title("Longitudinal Acceleration — Real vs Sim")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # --- Plot 7: Slip angle ---
+    ax = axes[6]
+    ax.plot(t[:n_real], real_beta[:n_real], label="Real slip (Vicon)", linewidth=1)
+    ax.plot(sim_t[:n_real], sim_beta[:n_real], label=f"Sim slip ({model_label})", linewidth=1.5, linestyle="--")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Slip angle β (rad)")
+    ax.set_title("Slip Angle — Real vs Sim")
     ax.legend()
     ax.grid(True, alpha=0.3)
 

--- a/gymkhana/envs/base_classes.py
+++ b/gymkhana/envs/base_classes.py
@@ -205,9 +205,10 @@ class RaceCar(object):
 
         Args:
             pose: Pose to reset to, shape ``(3,)`` as ``[x, y, yaw]``.
-            state: Full state for STD model, shape ``(7,)`` as
-                ``[x, y, delta, v, yaw, yaw_rate, slip_angle]``.
-                If provided, ``pose`` is ignored.
+            state: Optional model-specific user-facing state row; see
+                :meth:`gymkhana.envs.dynamic_models.DynamicModel.user_state_len`
+                for accepted widths and layouts. MB does not support full-state
+                reset. If provided, ``pose`` is ignored.
         """
         # clear control inputs
         self.accel = 0.0
@@ -557,9 +558,11 @@ class Simulator(object):
 
         Args:
             poses: Poses for all agents, shape ``(num_agents, 3)``.
-            states: Full states for STD model, shape ``(num_agents, 7)``,
-                each row ``[x, y, delta, v, yaw, yaw_rate, slip_angle]``.
-                If provided, ``poses`` is ignored.
+            states: Optional full states for all agents, shape ``(num_agents, n)``
+                where ``n`` is the model-specific row width; see
+                :meth:`gymkhana.envs.dynamic_models.DynamicModel.user_state_len`
+                for accepted widths and layouts. MB does not support full-state
+                reset. If provided, ``poses`` is ignored.
 
         Raises:
             ValueError: If the number of poses or states does not match ``num_agents``.

--- a/gymkhana/envs/dynamic_models/__init__.py
+++ b/gymkhana/envs/dynamic_models/__init__.py
@@ -90,7 +90,7 @@ class DynamicModel(Enum):
         """Return the DynamicModel enum value for a string identifier.
 
         Args:
-            model: One of ``"ks"``, ``"st"``, ``"mb"``, ``"std"``.
+            model: One of ``"ks"``, ``"st"``, ``"mb"``, ``"std"``, ``"stp"``.
 
         Returns:
             Corresponding :class:`DynamicModel` enum value.
@@ -112,14 +112,41 @@ class DynamicModel(Enum):
         else:
             raise ValueError(f"Unknown model type {model}")
 
+    def user_state_len(self) -> int:
+        """Return the user-facing state-row width accepted by full-state reset.
+
+        - KS  -> 5 ``[x, y, delta, v, yaw]``
+        - ST  -> 7 ``[x, y, delta, v, yaw, yaw_rate, slip_angle]``
+        - STP -> 7 (same layout as ST)
+        - STD -> 7 (same layout as ST; ``omega_f, omega_r`` are computed by ``init_std``)
+
+        Returns:
+            The expected state-row width for this model.
+
+        Raises:
+            ValueError: For MB, which has a 29D internal state with
+                suspension/wheel quantities a user cannot sensibly construct.
+        """
+        if self == DynamicModel.MB:
+            raise ValueError(
+                "Full-state initialization is not supported for the MB model. Use pose-based reset instead."
+            )
+        return {
+            DynamicModel.KS: 5,
+            DynamicModel.ST: 7,
+            DynamicModel.STP: 7,
+            DynamicModel.STD: 7,
+        }[self]
+
     def get_initial_state(self, pose=None, state=None, params: Optional[dict] = None):
         """
         Get the initial state for the vehicle model.
 
         Args:
-            pose: (3,) array [x, y, yaw] - legacy pose-only initialization
-            state: (7,) array for STD model [x, y, delta, v, yaw, yaw_rate, slip_angle]
-                   omega_f and omega_r are calculated automatically
+            pose: (3,) array [x, y, yaw] - legacy pose-only initialization.
+            state: Optional model-specific user-facing state row; see
+                :meth:`user_state_len` for accepted widths and layouts. MB
+                does not support full-state initialization.
             params: Vehicle parameters dictionary (required for MB and STD models)
 
         Returns:
@@ -152,13 +179,13 @@ class DynamicModel(Enum):
         else:
             raise ValueError(f"Unknown model type {self}")
 
-        # If full state provided, copy first 7 elements (STD model only)
+        # If full state provided, dispatch per model. Width and MB-rejection
+        # both come from DynamicModel.user_state_len so the rules live in one place.
         if state is not None:
-            if self != DynamicModel.STD:
-                raise ValueError(f"Full state initialization only supported for STD model, not {self}")
-            if len(state) != 7:
-                raise ValueError(f"STD model requires 7-element state, got {len(state)}")
-            init_state[:7] = state
+            expected_state_len = self.user_state_len()
+            if len(state) != expected_state_len:
+                raise ValueError(f"{self.name} model requires {expected_state_len}-element state, got {len(state)}")
+            init_state[:expected_state_len] = state
         # set initial pose if provided
         elif pose is not None:
             init_state[0:2] = pose[0:2]

--- a/gymkhana/envs/dynamic_models/__init__.py
+++ b/gymkhana/envs/dynamic_models/__init__.py
@@ -24,9 +24,11 @@ All dynamics functions accept a ``params`` dict. The keys used across models are
 
 **Tyre / lateral dynamics**
 
-- ``mu`` (float): Tyre–road friction coefficient. *(ST)*
+- ``mu`` (float): Tyre–road friction coefficient. *(ST, STP)*
 - ``C_Sf`` (float): Cornering stiffness of front tyres (N/rad). *(ST)*
 - ``C_Sr`` (float): Cornering stiffness of rear tyres (N/rad). *(ST)*
+- ``B_f, C_f, D_f, E_f`` (float): Front-axle Pacejka Magic Formula coefficients. *(STP)*
+- ``B_r, C_r, D_r, E_r`` (float): Rear-axle Pacejka Magic Formula coefficients. *(STP)*
 
 **Steering constraints**
 
@@ -62,6 +64,7 @@ from .kinematic import get_standardized_state_ks, vehicle_dynamics_ks
 from .multi_body import get_standardized_state_mb, init_mb, vehicle_dynamics_mb
 from .single_track import get_standardized_state_st, vehicle_dynamics_st
 from .single_track_drift import get_standardized_state_std, init_std, vehicle_dynamics_std
+from .single_track_pacejka import vehicle_dynamics_stp
 from .utils import bang_bang_steer, p_accl
 
 
@@ -73,12 +76,14 @@ class DynamicModel(Enum):
         ST: Single Track — lateral dynamics without an explicit tire model.
         MB: Multi-Body — full tire modeling and multi-body dynamics.
         STD: Single Track Drift — ST with PAC2002 tire model for drift simulation.
+        STP: Single Track Pacejka — ST with lateral-only Pacejka Magic Formula.
     """
 
     KS = 1  # Kinematic Single Track
     ST = 2  # Single Track
     MB = 3  # Multi-body Model
     STD = 4  # Single Track Drift
+    STP = 5  # Single Track Pacejka (lateral-only)
 
     @staticmethod
     def from_string(model: str):
@@ -102,6 +107,8 @@ class DynamicModel(Enum):
             return DynamicModel.MB
         elif model == "std":
             return DynamicModel.STD
+        elif model == "stp":
+            return DynamicModel.STP
         else:
             raise ValueError(f"Unknown model type {model}")
 
@@ -133,7 +140,7 @@ class DynamicModel(Enum):
         if self == DynamicModel.KS:
             # state is [x, y, steer_angle, vel, yaw_angle]
             init_state = np.zeros(5)
-        elif self == DynamicModel.ST:
+        elif self == DynamicModel.ST or self == DynamicModel.STP:
             # state is [x, y, steer_angle, vel, yaw_angle, yaw_rate, slip_angle]
             init_state = np.zeros(7)
         elif self == DynamicModel.MB:
@@ -176,6 +183,8 @@ class DynamicModel(Enum):
             return vehicle_dynamics_mb
         elif self == DynamicModel.STD:
             return vehicle_dynamics_std
+        elif self == DynamicModel.STP:
+            return vehicle_dynamics_stp
         else:
             raise ValueError(f"Unknown model type {self}")
 
@@ -193,5 +202,7 @@ class DynamicModel(Enum):
             return get_standardized_state_mb
         elif self == DynamicModel.STD:
             return get_standardized_state_std
+        elif self == DynamicModel.STP:
+            return get_standardized_state_st
         else:
             raise ValueError(f"Unknown model type {self}")

--- a/gymkhana/envs/dynamic_models/single_track_pacejka/__init__.py
+++ b/gymkhana/envs/dynamic_models/single_track_pacejka/__init__.py
@@ -1,0 +1,8 @@
+"""Single Track Pacejka (STP) vehicle dynamics model.
+
+Lateral-only Pacejka Magic Formula tire model on top of a dynamic single-track
+chassis. State shape matches ST (7 elements) — no longitudinal slip or
+wheel-spin states. Ported from f110-simulator's STDKinematics::update_pacejka.
+"""
+
+from .single_track_pacejka import vehicle_dynamics_stp

--- a/gymkhana/envs/dynamic_models/single_track_pacejka/single_track_pacejka.py
+++ b/gymkhana/envs/dynamic_models/single_track_pacejka/single_track_pacejka.py
@@ -1,0 +1,163 @@
+"""Single Track Pacejka (STP) vehicle dynamics model.
+
+Dynamic single-track bicycle with a Pacejka Magic Formula lateral tire model
+(no longitudinal slip dynamics). Ported from f110-simulator, and adjusted
+for this simulator. For the ref, see ``STDKinematics::update_pacejka`` (std_kinematics.cpp).
+https://github.com/ForzaETH/f1tenth_simulator
+
+Deviations from the C++ original:
+- State uses ``(V, beta)`` instead of ``(v_x, v_y)``; body-frame derivatives are
+  chain-ruled into ``(V_dot, beta_dot)``.
+- Returns derivatives only (gymkhana's RK4 integrates externally), so the
+  low-speed kinematic blend mixes *derivatives*, not post-integrated states.
+- Constraints applied inside ``f``.
+- Slip-angle sign flipped (gymkhana convention); ``F_y`` is negated to compensate
+  since Pacejka is odd in alpha.
+- Blend thresholds retuned for 1/10 scale (``v_s=0.2, v_b=0.05``) and gated on
+  ``V`` rather than ``v_x``; the hard ``w_std=0`` clamp below ``v_min`` is
+  replaced by a sharper tanh plus zeroing ``alpha`` and ``beta_dot`` below
+  ``v_min_blend``. Thresholds are overridable via params keys ``blend_v_s``,
+  ``blend_v_b``, ``blend_v_min`` (used by parity tests against the f110 ref).
+
+State extraction: STP shares the ST 7-element state layout, so the dispatch in
+``dynamic_models/__init__.py`` reuses ST's ``get_standardized_state_st`` for
+STP rather than defining a separate function here.
+"""
+
+import numpy as np
+
+from ..kinematic import vehicle_dynamics_ks_cog
+from ..utils import accl_constraints, steering_constraint
+
+
+def vehicle_dynamics_stp(x: np.ndarray, u_init: np.ndarray, params: dict) -> np.ndarray:
+    """Compute Single Track Pacejka vehicle dynamics.
+
+    Args:
+        x: State vector of shape ``(7,)``:
+            ``[x_pos, y_pos, steering_angle, velocity, yaw_angle, yaw_rate, slip_angle]``.
+        u_init: Control input ``[steering_velocity, acceleration]``.
+        params: Vehicle parameters dict. Required keys:
+            ``mu, lf, lr, h_s, m, I_z,
+            B_f, C_f, D_f, E_f, B_r, C_r, D_r, E_r,
+            s_min, s_max, sv_min, sv_max, v_switch, a_max, v_min, v_max``.
+
+    Returns:
+        Time derivatives of the state vector, shape ``(7,)``.
+    """
+    # State unpacking
+    DELTA = x[2]
+    V = x[3]
+    PSI = x[4]
+    PSI_DOT = x[5]
+    BETA = x[6]
+
+    # Constants
+    g = 9.81
+
+    # Low-speed blend thresholds (1/10-scale tuning, mirrors STD).
+    # Overridable via params for parity testing against the f110 reference.
+    v_s = params.get("blend_v_s", 0.2)
+    v_b = params.get("blend_v_b", 0.05)
+    v_min_blend = params.get("blend_v_min", v_s / 2)
+
+    # Apply input constraints (idempotent under RK4 sub-stages)
+    u = np.array(
+        [
+            steering_constraint(
+                DELTA,
+                u_init[0],
+                params["s_min"],
+                params["s_max"],
+                params["sv_min"],
+                params["sv_max"],
+            ),
+            accl_constraints(
+                V,
+                u_init[1],
+                params["v_switch"],
+                params["a_max"],
+                params["v_min"],
+                params["v_max"],
+            ),
+        ]
+    )
+    STEER_VEL = u[0]
+    ACCL = u[1]
+
+    lf = params["lf"]
+    lr = params["lr"]
+    lwb = lf + lr
+    m = params["m"]
+    I_z = params["I_z"]
+    h_s = params["h_s"]
+    mu = params["mu"]
+
+    # --- Lateral tire slip angles (gymkhana sign convention) ---
+    # Equivalent to f110's atan2(-v_y - lf*omega, v_x) + delta with v_y = V*sin(beta)
+    if V > v_min_blend:
+        denom = V * np.cos(BETA)
+        alpha_f = np.arctan((V * np.sin(BETA) + PSI_DOT * lf) / denom) - DELTA
+        alpha_r = np.arctan((V * np.sin(BETA) - PSI_DOT * lr) / denom)
+    else:
+        alpha_f = 0.0
+        alpha_r = 0.0
+
+    # --- Vertical loads with longitudinal weight transfer ---
+    F_zf = m * (-ACCL * h_s + g * lr) / lwb
+    F_zr = m * (ACCL * h_s + g * lf) / lwb
+
+    # --- Pacejka Magic Formula lateral forces ---
+    # Note: gymkhana sign convention has alpha = -alpha_f110, so we negate F_y to keep
+    # the body-frame equations identical to the f110 implementation.
+    Bf, Cf, Df, Ef = params["B_f"], params["C_f"], params["D_f"], params["E_f"]
+    Br, Cr, Dr, Er = params["B_r"], params["C_r"], params["D_r"], params["E_r"]
+    F_yf = -mu * Df * F_zf * np.sin(Cf * np.arctan(Bf * alpha_f - Ef * (Bf * alpha_f - np.arctan(Bf * alpha_f))))
+    F_yr = -mu * Dr * F_zr * np.sin(Cr * np.arctan(Br * alpha_r - Er * (Br * alpha_r - np.arctan(Br * alpha_r))))
+
+    # --- Body-frame derivatives (exact, no small-angle) ---
+    # v_x = V*cos(beta), v_y = V*sin(beta)
+    sin_beta = np.sin(BETA)
+    cos_beta = np.cos(BETA)
+    sin_delta = np.sin(DELTA)
+    cos_delta = np.cos(DELTA)
+
+    v_x_dot = ACCL - (1.0 / m) * F_yf * sin_delta + V * sin_beta * PSI_DOT
+    v_y_dot = (1.0 / m) * (F_yr + F_yf * cos_delta) - V * cos_beta * PSI_DOT
+    psi_ddot = (1.0 / I_z) * (-F_yr * lr + F_yf * lf * cos_delta)
+
+    # --- Chain-rule into (V_dot, beta_dot) ---
+    V_dot = v_x_dot * cos_beta + v_y_dot * sin_beta
+    if V > v_min_blend:
+        beta_dot = (v_y_dot * cos_beta - v_x_dot * sin_beta) / V
+    else:
+        beta_dot = 0.0
+
+    # --- Kinematic-bicycle derivatives for low-speed blend ---
+    x_ks = np.array([x[0], x[1], DELTA, V, PSI])
+    f_ks = vehicle_dynamics_ks_cog(x_ks, u, params)
+    V_dot_ks = f_ks[3]
+    psi_dot_ks = f_ks[4]
+    beta_dot_ks = (lr * STEER_VEL) / (lwb * cos_delta**2 * (1 + (np.tan(DELTA) ** 2 * lr / lwb) ** 2))
+    psi_ddot_ks = (1.0 / lwb) * (
+        ACCL * cos_beta * np.tan(DELTA)
+        - V * sin_beta * beta_dot_ks * np.tan(DELTA)
+        + V * cos_beta * STEER_VEL / cos_delta**2
+    )
+
+    # --- Blend derivatives ---
+    w_std = 0.5 * (np.tanh((V - v_s) / v_b) + 1.0)
+    w_ks = 1.0 - w_std
+
+    f = np.array(
+        [
+            V * np.cos(PSI + BETA),
+            V * np.sin(PSI + BETA),
+            STEER_VEL,
+            w_std * V_dot + w_ks * V_dot_ks,
+            w_std * PSI_DOT + w_ks * psi_dot_ks,
+            w_std * psi_ddot + w_ks * psi_ddot_ks,
+            w_std * beta_dot + w_ks * beta_dot_ks,
+        ]
+    )
+    return f

--- a/gymkhana/envs/gymkhana_env.py
+++ b/gymkhana/envs/gymkhana_env.py
@@ -1040,9 +1040,11 @@ class GKEnv(gym.Env):
 
                 - ``"poses"``: ``np.ndarray`` of shape ``(num_agents, 3)``
                   — ``[x, y, yaw]`` per agent.
-                - ``"states"``: ``np.ndarray`` of shape ``(num_agents, 7)``
-                  — ``[x, y, delta, v, yaw, yaw_rate, slip_angle]`` per agent
-                  (STD model only).
+                - ``"states"``: ``np.ndarray`` of shape ``(num_agents, n)`` where
+                  ``n`` is the model-specific row width; see
+                  :meth:`gymkhana.envs.dynamic_models.DynamicModel.user_state_len`
+                  for accepted widths and layouts. MB does not support
+                  full-state reset.
 
                 Cannot specify both keys simultaneously.
 
@@ -1083,21 +1085,24 @@ class GKEnv(gym.Env):
                 raise ValueError("Cannot provide both 'poses' and 'states' in reset options.")
 
             if has_states:
-                # Validate STD model requirement
-                if self.model != DynamicModel.STD:
-                    raise ValueError(
-                        f"Full state initialization only supported for STD model. "
-                        f"Current model: {self.model}. Optionally use 'poses' instead."
-                    )
+                # Per-model expected width (and MB rejection) come from
+                # DynamicModel.user_state_len; this layer only validates that
+                # the supplied 2-D array matches (num_agents, expected_len).
+                expected_state_len = self.model.user_state_len()
 
                 states = options["states"]
-                assert isinstance(states, np.ndarray) and states.shape == (
+                if not isinstance(states, np.ndarray) or states.shape != (
                     self.num_agents,
-                    7,
-                ), f"States must be a numpy array of shape (num_agents, 7), got {states.shape}"
+                    expected_state_len,
+                ):
+                    raise ValueError(
+                        f"States must be a numpy array of shape "
+                        f"(num_agents={self.num_agents}, {expected_state_len}) "
+                        f"for model {self.model.name}, got "
+                        f"{states.shape if isinstance(states, np.ndarray) else type(states).__name__}"
+                    )
 
                 # Save poses for downstream use
-                # State indices: [x, y, delta, v, yaw, yaw_rate, slip_angle]
                 poses = np.column_stack([states[:, 0], states[:, 1], states[:, 4]])
 
             elif has_poses:

--- a/gymkhana/envs/gymkhana_env.py
+++ b/gymkhana/envs/gymkhana_env.py
@@ -463,6 +463,20 @@ class GKEnv(gym.Env):
         return load_params("f1tenth_std")
 
     @classmethod
+    def f1tenth_stp_vehicle_params(cls) -> dict:
+        """Return default parameters for the 1/10th scale F1TENTH car (STP model).
+
+        Single Track Pacejka: dynamic single-track chassis with a lateral-only
+        Pacejka Magic Formula tyre model (8 coefficients, ``B_f, C_f, D_f, E_f,
+        B_r, C_r, D_r, E_r``). Coefficients are seeded from the on-track sysid
+        pipeline output (``SIM_pacejka.txt``).
+
+        Returns:
+            Complete parameter dictionary for the STP model.
+        """
+        return load_params("f1tenth_stp")
+
+    @classmethod
     def default_config(cls) -> dict:
         """Return the default environment configuration dict.
 

--- a/gymkhana/envs/gymkhana_env.py
+++ b/gymkhana/envs/gymkhana_env.py
@@ -275,16 +275,24 @@ class GKEnv(gym.Env):
                 "Please set model='std' (or model=DynamicModel.STD) when creating the environment."
             )
 
+        # Validate drift_st observation requires ST or STP model
+        if obs_type == "drift_st" and self.model not in [DynamicModel.ST, DynamicModel.STP]:
+            raise ValueError(
+                "The 'drift_st' observation type requires the single_track (ST) or single_track_pacejka (STP) model. "
+                f"Current model: {self.model}. "
+                "Please set model='st' or 'stp' (or model=DynamicModel.ST, model=DynamicModel.STP) when creating the environment."
+            )
+
         # Handle normalization configuration
         normalize_obs = self.config["normalize_obs"]
 
         # Identify whether the chosen observation type is supported for normalization
-        supported_obs_types = ["drift", "race", "frenet"]
+        supported_obs_types = ["drift", "race", "frenet", "drift_st"]
         obs_norm_supported = obs_type in supported_obs_types
 
         if normalize_obs is None:
             # User did not set normalize - auto-set based on observation type
-            # Default to True for observation types that support normalization (drift, race, frenet, etc.)
+            # Default to True for observation types that support normalization (drift, race, etc.)
             self.normalize_obs = obs_norm_supported
         else:
             # User explicitly set normalize

--- a/gymkhana/envs/observation.py
+++ b/gymkhana/envs/observation.py
@@ -826,7 +826,7 @@ def observation_factory(env, type: str | None, **kwargs) -> Observation:
         type: Observation type string. Supported values:
             ``"original"``, ``"features"``, ``"kinematic_state"``,
             ``"dynamic_state"``, ``"frenet_dynamic_state"``, ``"rl"``,
-            ``"drift"``, ``"frenet"``, ``"race"``.
+            ``"drift"``, ``"frenet"``, ``"race"``, ``"drift_st"``.
             Defaults to ``"original"`` if None.
         **kwargs: Additional arguments forwarded to the observation constructor.
 
@@ -851,6 +851,7 @@ def observation_factory(env, type: str | None, **kwargs) -> Observation:
             "pose_y",
             "delta",
             "linear_vel_x",
+            "linear_vel_y",
             "pose_theta",
             "ang_vel_z",
             "beta",
@@ -886,6 +887,19 @@ def observation_factory(env, type: str | None, **kwargs) -> Observation:
             "prev_accl_cmd",  # ω_dot_ref - last control input (acceleration)
             "prev_avg_wheel_omega",  # ω - previous measured wheel speed
             "curr_vel_cmd",  # ω_ref - current commanded velocity (integrated from acceleration)
+            "lookahead_curvatures",  # c - track curvatures
+            "lookahead_widths",  # w - track widths
+        ]
+        return VectorObservation(env, features=features)
+    elif type == "drift_st":
+        features = [
+            "linear_vel_x",  # vx - longitudinal velocity, vehicle frame
+            "linear_vel_y",  # vy - lateral velocity, vehicle frame
+            "frenet_u",  # u - angle between car heading, track heading, in Frenet coords
+            "frenet_n",  # n - lateral distance from centerline, in Frenet coords
+            "ang_vel_z",  # r - yaw rate
+            "beta",  # β - slip angle (vehicle velocity angle relative to body axis)
+            "prev_steering_cmd",  # δ - measured steering angle
             "lookahead_curvatures",  # c - track curvatures
             "lookahead_widths",  # w - track widths
         ]

--- a/gymkhana/envs/observation.py
+++ b/gymkhana/envs/observation.py
@@ -899,7 +899,7 @@ def observation_factory(env, type: str | None, **kwargs) -> Observation:
             "frenet_n",  # n - lateral distance from centerline, in Frenet coords
             "ang_vel_z",  # r - yaw rate
             "beta",  # β - slip angle (vehicle velocity angle relative to body axis)
-            "prev_steering_cmd",  # δ - measured steering angle
+            "prev_steering_cmd",  # δ_ref - previous commanded steering angle
             "lookahead_curvatures",  # c - track curvatures
             "lookahead_widths",  # w - track widths
         ]

--- a/gymkhana/envs/params/f1tenth_stp.yaml
+++ b/gymkhana/envs/params/f1tenth_stp.yaml
@@ -1,0 +1,49 @@
+# Default parameters for the 1/10th scale F1TENTH car (STP model).
+# Single Track Pacejka: dynamic single-track chassis with a Pacejka Magic
+# Formula lateral tire model (no longitudinal slip / wheel-spin states).
+#
+# Pacejka coefficients seeded from the on-track sysid pipeline output:
+#   race_stack/system_identification/on_track_sys_id/models/SIM/SIM_pacejka.txt
+# Note: that file folds friction into D and uses no separate mu. Here mu is
+# kept as an explicit multiplier (matches the f110-simulator update_pacejka
+# convention). Set mu=1.0 below for sysid-faithful behavior.
+
+# =========================
+# Geometry / inertia
+# =========================
+m: 3.74           # mass [kg]
+I_z: 0.04712      # yaw moment of inertia [kg m^2]
+lf: 0.15875       # CoG to front axle [m]
+lr: 0.17145       # CoG to rear axle [m]
+h_s: 0.074        # CoG height (sprung mass) [m]
+width: 0.31
+length: 0.58
+
+# =========================
+# Friction & Pacejka lateral tire coefficients
+# =========================
+mu: 1.0489        # explicit lateral friction multiplier; sysid expects mu=1.0
+B_f: 6.6185       # front stiffness factor
+C_f: 1.6102       # front shape factor
+D_f: 0.652        # front peak factor (μ-equivalent, dimensionless)
+E_f: 0.7826       # front curvature factor
+B_r: 7.9507       # rear stiffness factor
+C_r: 3.692        # rear shape factor
+D_r: 0.6691       # rear peak factor
+E_r: 0.5595       # rear curvature factor
+
+# =========================
+# Steering constraints
+# =========================
+s_min: -0.52  # originally -0.4189
+s_max: 0.52  # originally 0.4189
+sv_min: -4.95 # originally -3.2
+sv_max: 4.95 # originally 3.2
+
+# =========================
+# Longitudinal constraints
+# =========================
+v_switch: 7.319
+a_max: 6.0
+v_min: -5.0
+v_max: 20.0

--- a/tests/test_env_reset.py
+++ b/tests/test_env_reset.py
@@ -420,7 +420,7 @@ class TestFullStateReset(unittest.TestCase):
         """Test that wrong state shape raises clear error."""
         wrong_states = np.array([[0.0, 0.0, 0.0]])  # Only 3 elements instead of 7
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.env.reset(options={"states": wrong_states})
 
     def test_wrong_num_agents_error(self):
@@ -439,28 +439,29 @@ class TestFullStateReset(unittest.TestCase):
 
         states = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])  # Only 1 agent
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             env.reset(options={"states": states})
 
         env.close()
 
-    def test_non_std_model_states_error(self):
-        """Test that using states with non-STD model raises error."""
+    def test_mb_model_states_rejected(self):
+        """Test that full-state reset is rejected for the MB model."""
         env = gym.make(
             "gymkhana:gymkhana-v0",
             config={
                 "map": "Spielberg",
                 "num_agents": 1,
-                "model": "st",  # Single Track model, not STD
+                "model": "mb",
+                "params": GKEnv.fullscale_vehicle_params(),
                 "observation_config": {"type": None},
             },
         )
 
-        states = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
+        states = np.zeros((1, 7))
 
         with self.assertRaises(ValueError) as ctx:
             env.reset(options={"states": states})
-        self.assertIn("only supported for STD model", str(ctx.exception))
+        self.assertIn("MB", str(ctx.exception))
 
         env.close()
 
@@ -710,6 +711,58 @@ class TestSkipIntegration(unittest.TestCase):
             decimal=5,
             err_msg="State should NOT be modified when skip_integration=True",
         )
+
+
+class TestNonStdFullStateReset(unittest.TestCase):
+    """Full-state reset for KS / ST / STP. STD coverage lives in TestFullStateReset.
+
+    Multi-agent + wrong-num-agents paths are model-independent and already
+    covered by the existing STD tests; the rejection-side check here uses ST.
+    """
+
+    def test_full_state_reset_supported_models(self):
+        """Every supported non-STD model accepts a row of its expected width."""
+        cases = [
+            ("ks", np.array([1.0, 2.0, 0.1, 4.0, np.pi / 4]), None),
+            ("st", np.array([1.0, 2.0, 0.1, 4.0, np.pi / 4, 0.3, 0.05]), None),
+            ("stp", np.array([1.0, 2.0, 0.1, 4.0, np.pi / 4, 0.3, 0.05]), GKEnv.f1tenth_stp_vehicle_params()),
+        ]
+        for model, row, params in cases:
+            with self.subTest(model=model):
+                config = {
+                    "map": "Spielberg",
+                    "num_agents": 1,
+                    "model": model,
+                    "observation_config": {"type": None},
+                    "reset_config": {"type": "rl_random_static"},
+                }
+                if params is not None:
+                    config["params"] = params
+                env = gym.make("gymkhana:gymkhana-v0", config=config)
+                try:
+                    env.reset(options={"states": row.reshape(1, -1)})
+                    state = env.unwrapped.sim.agents[0].state
+                    np.testing.assert_array_almost_equal(state, row, decimal=5)
+                finally:
+                    env.close()
+
+    def test_full_state_wrong_width_rejected(self):
+        """Wrong row width raises ValueError. ST chosen as a representative."""
+        env = gym.make(
+            "gymkhana:gymkhana-v0",
+            config={
+                "map": "Spielberg",
+                "num_agents": 1,
+                "model": "st",
+                "observation_config": {"type": None},
+                "reset_config": {"type": "rl_random_static"},
+            },
+        )
+        try:
+            with self.assertRaises(ValueError):
+                env.reset(options={"states": np.zeros((1, 5))})  # ST expects 7
+        finally:
+            env.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_normalize_config.py
+++ b/tests/test_normalize_config.py
@@ -152,6 +152,96 @@ def test_normalize_override_false_with_drift():
 
 
 # ============================================================================
+# Observation Type / Model Pairing Validation Tests
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "obs_type, model, params_factory, expect_error",
+    [
+        ("drift", "std", GKEnv.f1tenth_std_vehicle_params, False),
+        ("drift", "st", GKEnv.f1tenth_vehicle_params, True),
+        ("drift_st", "st", GKEnv.f1tenth_vehicle_params, False),
+        ("drift_st", "stp", GKEnv.f1tenth_stp_vehicle_params, False),
+        ("drift_st", "std", GKEnv.f1tenth_std_vehicle_params, True),
+        ("drift_st", "ks", GKEnv.f1tenth_vehicle_params, True),
+    ],
+)
+def test_obs_type_model_pairing(obs_type, model, params_factory, expect_error):
+    """Validate that each obs_type only accepts its compatible vehicle models."""
+    cfg = {
+        "map": "Spielberg",
+        "num_agents": 1,
+        "model": model,
+        "observation_config": {"type": obs_type},
+        "params": params_factory(),
+    }
+    if expect_error:
+        with pytest.raises(ValueError, match=f"'{obs_type}' observation type requires"):
+            gym.make("gymkhana:gymkhana-v0", config=cfg)
+    else:
+        env = gym.make("gymkhana:gymkhana-v0", config=cfg)
+        assert env.unwrapped.observation_config["type"] == obs_type
+        env.close()
+
+
+_DRIFT_ST_MODELS = [
+    ("st", GKEnv.f1tenth_vehicle_params),
+    ("stp", GKEnv.f1tenth_stp_vehicle_params),
+]
+
+
+@pytest.mark.parametrize("model, params_factory", _DRIFT_ST_MODELS)
+def test_drift_st_normalize_obs_default_true(model, params_factory):
+    """Test that normalize_obs=True by default for 'drift_st' obs across compatible models."""
+    env = gym.make(
+        "gymkhana:gymkhana-v0",
+        config={
+            "map": "Spielberg",
+            "num_agents": 1,
+            "model": model,
+            "observation_config": {"type": "drift_st"},
+            "params": params_factory(),
+        },
+    )
+    assert env.unwrapped.normalize_obs is True
+    env.close()
+
+
+@pytest.mark.parametrize("model, params_factory", _DRIFT_ST_MODELS)
+def test_drift_st_end_to_end_normalized(model, params_factory):
+    """Validate complete drift_st observation pipeline with normalization across compatible models."""
+    env = gym.make(
+        "gymkhana:gymkhana-v0",
+        config={
+            "map": "Spielberg",
+            "num_agents": 1,
+            "model": model,
+            "observation_config": {"type": "drift_st"},
+            "params": params_factory(),
+            "normalize_obs": True,
+        },
+    )
+
+    obs, _ = env.reset()
+
+    for _ in range(10):
+        action = env.action_space.sample()
+        obs, _, terminated, truncated, _ = env.step(action)
+
+        assert np.all(obs >= -1.0), f"Observation has values < -1.0: min={np.min(obs)}"
+        assert np.all(obs <= 1.0), f"Observation has values > 1.0: max={np.max(obs)}"
+        assert obs.shape == env.observation_space.shape, "Observation shape mismatch"
+        assert obs.dtype == np.float32, f"Expected dtype float32, got {obs.dtype}"
+        assert env.observation_space.contains(obs), "Observation not in declared space"
+
+        if terminated or truncated:
+            break
+
+    env.close()
+
+
+# ============================================================================
 # Action Normalization Configuration Tests
 # ============================================================================
 

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -151,6 +151,7 @@ class TestObservationInterface(unittest.TestCase):
             "pose_y",
             "pose_theta",
             "linear_vel_x",
+            "linear_vel_y",
             "ang_vel_z",
             "delta",
             "beta",
@@ -167,7 +168,15 @@ class TestObservationInterface(unittest.TestCase):
         obs, _, _, _, _ = env.step(env.action_space.sample())
 
         for i, agent_id in enumerate(env.unwrapped.agent_ids):
-            pose_x, pose_y, delta, velx, pose_theta, _, beta = env.unwrapped.sim.agents[i].state
+            std_state = env.unwrapped.sim.agents[i].standard_state
+            pose_x = std_state["x"]
+            pose_y = std_state["y"]
+            pose_theta = std_state["yaw"]
+            velx = std_state["v_x"]
+            vely = std_state["v_y"]
+            delta = std_state["delta"]
+            ang_vel_z = std_state["yaw_rate"]
+            beta = std_state["slip"]
 
             agent_obs = obs[agent_id]
             obs_x, obs_y, obs_theta = (
@@ -175,15 +184,17 @@ class TestObservationInterface(unittest.TestCase):
                 agent_obs["pose_y"],
                 agent_obs["pose_theta"],
             )
-            obs_velx, obs_delta, obs_beta = (
+            obs_velx, obs_vely, obs_delta, obs_beta, obs_ang_vel_z = (
                 agent_obs["linear_vel_x"],
+                agent_obs["linear_vel_y"],
                 agent_obs["delta"],
                 agent_obs["beta"],
+                agent_obs["ang_vel_z"],
             )
 
             for ground_truth, observed in zip(
-                [pose_x, pose_y, pose_theta, velx, delta, beta],
-                [obs_x, obs_y, obs_theta, obs_velx, obs_delta, obs_beta],
+                [pose_x, pose_y, pose_theta, velx, vely, delta, beta, ang_vel_z],
+                [obs_x, obs_y, obs_theta, obs_velx, obs_vely, obs_delta, obs_beta, obs_ang_vel_z],
             ):
                 self.assertTrue(np.allclose(ground_truth, observed))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed plan/spec for a new Single-Track Pacejka (STP) dynamics model and a default STP parameter file.
* **New Features**
  * Added STP vehicle dynamics, environment support and a public helper to load STP params; reset API now accepts model-specific full-state widths.
  * Added a new "drift_st" observation type and included lateral velocity in dynamic observations.
* **Examples / Validation**
  * Added analysis, smoke-check, and validation scripts and enhanced trajectory plotting to compare/verify ST vs STP.
* **Tests**
  * Updated and added tests for reset validation and observation/normalization behavior including the new observation type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->