### PR TITLE
Enable multi bag sysid

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ git clone --recurse-submodules https://github.com/TeoIlie/Gym-Khana.git
 cd Gym-Khana
 poetry install --all-groups
 source $(poetry env info -p)/bin/activate # or instead of sourcing, prefix commands with `poetry run`
+pre-commit install # wire up the git hook for ruff formatting/linting on commit
 ```
 
 Then you're off to the races! 🏎️
@@ -311,6 +312,8 @@ Custom maps can be created using the git submodule <https://github.com/TeoIlie/F
 ### Formatting/Linting
 
 Run formatting and auto-fixes manually with `ruff check --fix . && ruff format .` Fixes also are applied before commits due to `.pre-commit-config.yaml` file, with `pre-commit` dependency.
+
+`poetry install` provides `pre-commit`, but the git hook is wired up once per clone with `pre-commit install`. After that, ruff runs on staged files at every commit. Run `pre-commit run --all-files` to check the whole repo.
 
 ### Documentation
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,6 +31,15 @@ Using poetry
    poetry install
    source $(poetry env info -p)/bin/activate  # or prefix commands with `poetry run`
 
+Pre-commit hooks
+----------------
+
+``poetry install`` provides ``pre-commit``, but the git hook is wired up once per clone with ``pre-commit install``. After that, ruff runs on staged files at every commit. Run ``pre-commit run --all-files`` to check the whole repo.
+
+.. code:: bash
+
+   pre-commit install
+
 .. _additional-dependencies:
 
 Additional dependencies

--- a/docs/plan/OPTUNA_SYS_ID.md
+++ b/docs/plan/OPTUNA_SYS_ID.md
@@ -11,7 +11,7 @@ This repo's STD (Single-Track Drift) dynamics model uses PAC2002 tire parameters
 ## Pipeline
 
 ```
-load_dataset(bag.npz)          # → list[Window]
+load_dataset(bag.npz)          # → list[Window]   (or load_datasets([...]) for multi-bag concat)
         │
         ▼
 Rollout(env)                   # one GKEnv; set_params hot-swaps PAC2002 coefficients
@@ -25,6 +25,18 @@ Optuna study (CMA-ES, JournalStorage)  # 6-D Stage-1, 4-D Stage-2
         ▼
 f1tenth_std_optuna_stage{1,2}.yaml
 ```
+
+### Multi-bag
+
+`--bag` is repeatable on both `study.py` and `validate.py`. Bags are sorted by resolved path (then deduped) and their windows concatenated into one Dataset. Weighting is **equal-per-window** — a 200-window bag contributes 10× more than a 20-window bag. All bags share the same search space, mirror flag, channel coefficients, and `dt` (asserted at load). Each `Window` carries its `source_bag` for downstream diagnostics. With N>1 bags, `--study-name` (study.py) / `--out-dir` (validate.py) is required since auto-naming from a single bag stem no longer applies.
+
+Provenance is stamped in three places so a YAML found six months later is self-describing:
+
+1. **Output YAML header** — one `# bag:` line per bag (durable, ships with the params).
+2. **Optuna study user-attrs** — `study.user_attrs["bags"]` and `["stage"]`, persisted in JournalStorage.
+3. **wandb run config** — `bags` (list of stems), `n_bags`, `bag_window_counts` (per-bag window count).
+
+`validate.py` additionally writes a per-bag raw_MSE diagnostic table in the aggregated `metrics.txt` — large variance on a channel across bags is the signal that the balanced coefficients are averaging over disagreeing bags, and the bag selection should be reconsidered.
 
 ## Module map
 
@@ -97,7 +109,7 @@ If Stage 1's results show clean chassis correction and Stage 2 isn't needed (or 
 **Run a study:**
 
 ```bash
-# Stage 1 (default base = SYSID_PARAMS)
+# Stage 1 (default base = SYSID_PARAMS), single bag
 python -m examples.analysis.sysid.study \
     --bag examples/analysis/bags/<bag>.npz \
     --stage 1 --n-trials 500
@@ -107,9 +119,16 @@ python -m examples.analysis.sysid.study \
     --bag examples/analysis/bags/<bag>.npz \
     --stage 2 --n-trials 500 \
     --base-params gymkhana/envs/params/f1tenth_std_optuna_stage1.yaml
+
+# Multi-bag (study-name required)
+python -m examples.analysis.sysid.study \
+    --bag examples/analysis/bags/<bag_a>.npz \
+    --bag examples/analysis/bags/<bag_b>.npz \
+    --stage 1 --n-trials 500 \
+    --study-name myrun_stage1
 ```
 
-Auto-derived defaults: `--study-name` is `<bag_stem>_stage{N}`, `--storage` is `<repo>/studies/<study_name>.journal` (path to the JournalStorage file), `--out-yaml` is `gymkhana/envs/params/f1tenth_std_optuna_stage{N}.yaml`. Re-running the same name continues the existing study.
+Auto-derived defaults: `--study-name` is `<bag_stem>_stage{N}` (single-bag only), `--storage` is `<repo>/studies/<study_name>.journal` (path to the JournalStorage file), `--out-yaml` is `gymkhana/envs/params/f1tenth_std_optuna_stage{N}.yaml`. Re-running the same name continues the existing study.
 
 **Parallel workers** (CMA-ES degrades past ~4):
 
@@ -119,6 +138,20 @@ for i in 1 2 3 4; do
   python -m examples.analysis.sysid.study --bag <path> --stage 1 \
     --study-name myrun_stage1 --n-trials 125 &
 done; wait
+```
+
+`launch_study.sh` wraps the above and also accepts a `.txt` bag-list file (one NPZ path per line, `#`-comments allowed) as the first positional arg — the bag-list filename stem becomes the study name and every worker gets all bags via repeated `--bag` flags:
+
+```bash
+# Single-bag
+./examples/analysis/sysid/launch_study.sh examples/analysis/bags/<bag>.npz stage1
+
+# Multi-bag via list file
+cat > examples/analysis/bags/may26_set.txt <<EOF
+examples/analysis/bags/<bag_a>.npz
+examples/analysis/bags/<bag_b>.npz
+EOF
+./examples/analysis/sysid/launch_study.sh examples/analysis/bags/may26_set.txt stage1
 ```
 
 **Live monitoring via wandb** (always on):

--- a/docs/plan/OPTUNA_SYS_ID.md
+++ b/docs/plan/OPTUNA_SYS_ID.md
@@ -20,10 +20,10 @@ Rollout(env)                   # one GKEnv; set_params hot-swaps PAC2002 coeffic
 dataset_loss                   # fixed-scale weighted MSE on {yaw_rate, v_y, a_x, v_x, omega}
         │
         ▼
-Optuna study (CMA-ES, JournalStorage)  # 6-D Stage-1, 4-D Stage-2
+Optuna study (CMA-ES, JournalStorage)  # stages: steer_lag, vehicle_dyn, fine_tune
         │
         ▼
-f1tenth_std_optuna_stage{1,2}.yaml
+f1tenth_std_optuna_{steer_lag,vehicle_dyn,fine_tune}.yaml
 ```
 
 ### Multi-bag
@@ -46,7 +46,7 @@ Provenance is stamped in three places so a YAML found six months later is self-d
 | `examples/analysis/sysid/loss.py` | 77 | `channel_loss`, `window_loss`, `dataset_loss`. Pure functions. |
 | `examples/analysis/sysid/rollout.py` | 361 | `Rollout` (one env, hot-swap params, NaN guard). Includes a CLI sim-vs-real overlay plot. |
 | `examples/analysis/sysid/sensitivity.py` | 203 | OAT sweep tool — `run_sweep`, console ranking, CSV. Used to lock the search space; archived for re-runs on new bags. |
-| `examples/analysis/sysid/search_spaces.py` | 79 | Stage-1 / Stage-2 distributions, `apply_trial_params`, import-time invariants. |
+| `examples/analysis/sysid/search_spaces.py` | 79 | Stage distributions (`steer_lag`, `vehicle_dyn`, `fine_tune`), `apply_trial_params`, import-time invariants. |
 | `examples/analysis/sysid/study.py` | 166 | `Objective`, `build_study`, `dump_best_params`, CLI. |
 | `examples/analysis/sysid/env.py` | 12 | `SYSID_PARAMS = GKEnv.f1tenth_std_vehicle_params()` (canonical base dict). |
 | `tests/sysid/` | 6 files | Full coverage; runs in ~30 s. |
@@ -62,81 +62,65 @@ Provenance is stamped in three places so a YAML found six months later is self-d
 | Warmup discard | 0.2 s | Eats steering-servo transient from `delta_init = cmd_steer[t0]`. |
 | Reset state | 9-element STD user state, `omega = rs_core_speed/R_w` (AWD) | `env.reset(options={"states": ...})` accepts 9-wide. |
 | Mirroring | Off by default; opt-in via `--mirror` | STD is *near*-symmetric: PAC2002 shift terms (`p_hy1`, `p_vy1`, `p_hx1`, `p_vx1`, plus camber-coupled `p_hy3`/`p_vy3`/`p_dy3`/`p_dx3`) break exact L/R symmetry and are all frozen in the search space, so the model can only fit the symmetric component of the data anyway. On a balanced L+R bag, mirroring is a near-no-op that doubles compute. On a single-handed bag, opt in via `--mirror` to project the fit onto the symmetric subspace and avoid params absorbing the bag's directional bias. |
-| Sampler | `CmaEsSampler(seed=...)` | 6-D continuous + parameter coupling — CMA-ES wheelhouse. |
+| Sampler | `CmaEsSampler(seed=...)` | Continuous + parameter coupling — CMA-ES wheelhouse. |
 | Pruner | None (v1) | Pruning is a runtime optimization, not correctness. Add only if cost demands. |
 | Storage | `JournalStorage` at `<repo>/studies/<name>.journal` | Append-only log file, race-free for parallel workers (no DDL, no schema, no alembic). |
 | Resume | `load_if_exists=True` | Same study-name continues; new name = fresh study. |
-| Stage chaining | Via `base_params` | Stage 1 / 2 search spaces are disjoint — Stage 2 loads Stage 1 best YAML. |
+| Stage chaining | Via `base_params` | Stages are run in order (`steer_lag` → `vehicle_dyn` → `fine_tune`); each loads the prior stage's best YAML as its base. |
 | NaN handling | Map to `inf` | Trial COMPLETE with infinite value, never FAIL. |
 
 ## Search spaces (locked by Phase-2 sensitivity analysis)
 
-Full justification in [`OPTUNA_SYS_ID_SENSITIVITY_REPORT.md`](OPTUNA_SYS_ID_SENSITIVITY_REPORT.md).
+Full justification in [`OPTUNA_SYS_ID_SENSITIVITY_REPORT.md`](OPTUNA_SYS_ID_SENSITIVITY_REPORT.md). Authoritative bounds live in `examples/analysis/sysid/search_spaces.py` — refer to source, not this doc, for current numbers.
 
-**Stage 1 — chassis + linear regime (6 params):**
+Three stages, run in order:
 
-| param | bounds | source |
-|---|---|---|
-| `I_z` | `[0.05, 0.20]` | physical prior; wide-δ minimum past +200% |
-| `a_max` | `[1.0, 6.0]` | physical prior; wide-δ minimum at lower edge |
-| `I_y_w` | `[0.0005, 0.0025]` | auto-proposed |
-| `tire_p_cy1` | `[0.34, 2.36]` | auto-proposed |
-| `tire_p_cx1` | `[1.03, 2.26]` | auto-proposed |
-| `tire_p_ky1` | `[-80, -15]` | physical prior |
-
-**Stage 2 — saturation (4 params, run after Stage 1 with `--base-params <stage1.yaml>`):**
-
-| param | bounds | source |
-|---|---|---|
-| `tire_p_dy1` | `[0.7, 1.5]` | physical prior (μ_y) |
-| `tire_p_dx1` | `[0.7, 1.5]` | physical prior (μ_x) |
-| `tire_p_ey1` | `[-0.013, -0.0019]` | auto-proposed |
-| `tire_p_ex1` | `[0.12, 0.81]` | auto-proposed |
+- **`steer_lag`** — steering actuator dynamics (`sv_max`, `T_steer`; `sv_min` mirrored via `SYMMETRIC_PAIRS`). Collect on high-friction tires with yaw/heading-weighted loss.
+- **`vehicle_dyn`** — chassis + primary tire (`I_z`, `I_y_w`, `h_s`, `R_w`, `a_max`, `tire_p_dx1`, `tire_p_kx1`, `tire_p_dy1`, `tire_p_ky1`). Run after `steer_lag` with `--base-params <steer_lag.yaml>`.
+- **`fine_tune`** — PAC2002 shape/curvature + combined-slip terms (17 params: `tire_p_{cx1,ex1,cy1,ey1}`, `tire_r_b{x1,x2}`, `tire_r_b{y1,y2,y3}`, `tire_r_{cx1,ex1,cy1,ey1}`, `tire_r_v{y1,y4,y5,y6}`). Run after `vehicle_dyn` with `--base-params <vehicle_dyn.yaml>`.
 
 **Permanently frozen** (camber-coupled + pure-shift, see report §5):
 `tire_p_dx3`, `tire_p_dy3`, `tire_p_hy3`, `tire_p_vy3`, `tire_p_hx1`, `tire_p_vx1`, `tire_p_hy1`, `tire_p_vy1`.
 
-`T_steer` was evaluated and excluded — partly because of a `set_params` propagation bug (see Deferred Upgrades), partly because realistic sensitivity is too low for Stage-1 inclusion.
-
 ## Why staged?
 
-When two params can both reduce the same residual, joint optimization picks whichever combination minimizes loss — not whichever is *physically correct*. Phase-2's wide-δ pass showed `dy1` / `dx1` wanting to drift to non-physical μ values (>3.0 / <0.15) because they were sponging chassis-inertia error. Locking chassis params (`I_z`, `a_max`, `I_y_w`) first means tire-saturation params have a meaningful residual to fit, not a ghost of the chassis error.
+When two params can both reduce the same residual, joint optimization picks whichever combination minimizes loss — not whichever is *physically correct*. Phase-2's wide-δ pass showed `dy1` / `dx1` wanting to drift to non-physical μ values (>3.0 / <0.15) because they were sponging chassis-inertia error. Locking steering and chassis dynamics first means tire-saturation/combined-slip params have a meaningful residual to fit, not a ghost of upstream error.
 
-If Stage 1's results show clean chassis correction and Stage 2 isn't needed (or pushes against bounds, indicating the staging assumption broke), reconsider. A single 10-D joint study is the fallback.
+If a stage's results push against bounds or fail to improve on its base YAML, the staging assumption broke — reconsider before running the next stage. A single joint study over all params is the fallback.
 
 ## CLI usage
 
 **Run a study:**
 
 ```bash
-# Stage 1 (default base = SYSID_PARAMS), single bag
+# vehicle_dyn (default base = SYSID_PARAMS, or chain from steer_lag), single bag
 python -m examples.analysis.sysid.study \
     --bag examples/analysis/bags/<bag>.npz \
-    --stage 1 --n-trials 500
+    --stage vehicle_dyn --n-trials 500
 
-# Stage 2 (uses Stage 1 best as base)
+# fine_tune (uses vehicle_dyn best as base)
 python -m examples.analysis.sysid.study \
     --bag examples/analysis/bags/<bag>.npz \
-    --stage 2 --n-trials 500 \
-    --base-params gymkhana/envs/params/f1tenth_std_optuna_stage1.yaml
+    --stage fine_tune --n-trials 2000 \
+    --base-params gymkhana/envs/params/f1tenth_std_optuna_vehicle_dyn.yaml
 
 # Multi-bag (study-name required)
 python -m examples.analysis.sysid.study \
     --bag examples/analysis/bags/<bag_a>.npz \
     --bag examples/analysis/bags/<bag_b>.npz \
-    --stage 1 --n-trials 500 \
-    --study-name myrun_stage1
+    --stage vehicle_dyn --n-trials 500 \
+    --study-name myrun_vehicle_dyn
 ```
 
-Auto-derived defaults: `--study-name` is `<bag_stem>_stage{N}` (single-bag only), `--storage` is `<repo>/studies/<study_name>.journal` (path to the JournalStorage file), `--out-yaml` is `gymkhana/envs/params/f1tenth_std_optuna_stage{N}.yaml`. Re-running the same name continues the existing study.
+Auto-derived defaults: `--study-name` is `<bag_stem>_<stage>` (single-bag only), `--storage` is `<repo>/studies/<study_name>.journal` (path to the JournalStorage file), `--out-yaml` is `gymkhana/envs/params/f1tenth_std_optuna_<stage>.yaml`. Re-running the same name continues the existing study.
 
 **Parallel workers** (CMA-ES degrades past ~4):
 
 ```bash
 mkdir -p studies
 for i in 1 2 3 4; do
-  python -m examples.analysis.sysid.study --bag <path> --stage 1 \
-    --study-name myrun_stage1 --n-trials 125 &
+  python -m examples.analysis.sysid.study --bag <path> --stage vehicle_dyn \
+    --study-name myrun_vehicle_dyn --n-trials 125 &
 done; wait
 ```
 
@@ -144,14 +128,14 @@ done; wait
 
 ```bash
 # Single-bag
-./examples/analysis/sysid/launch_study.sh examples/analysis/bags/<bag>.npz stage1
+./examples/analysis/sysid/launch_study.sh examples/analysis/bags/<bag>.npz vehicle_dyn
 
 # Multi-bag via list file
 cat > examples/analysis/bags/may26_set.txt <<EOF
 examples/analysis/bags/<bag_a>.npz
 examples/analysis/bags/<bag_b>.npz
 EOF
-./examples/analysis/sysid/launch_study.sh examples/analysis/bags/may26_set.txt stage1
+./examples/analysis/sysid/launch_study.sh examples/analysis/bags/may26_set.txt vehicle_dyn
 ```
 
 **Live monitoring via wandb** (always on):

--- a/examples/analysis/sysid/dataset.py
+++ b/examples/analysis/sysid/dataset.py
@@ -18,7 +18,8 @@ See docs/plan/OPTUNA_SYS_ID.md for the locked design decisions.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from pathlib import Path
 
 import numpy as np
 from scipy.signal import savgol_filter
@@ -55,6 +56,10 @@ class Window:
     real_yaw: np.ndarray  # shape (N+1,) — unwrapped vicon_yaw
     real_beta: np.ndarray  # shape (N+1,) — arctan2(vy, vx)
     is_mirrored: bool
+    # Resolved absolute path of the source NPZ. Empty when the window was built
+    # by load_dataset directly (back-compat); stamped by load_dataset_tagged /
+    # load_datasets so multi-bag callers can group windows by origin.
+    source_bag: str = ""
 
 
 @dataclass(frozen=True)
@@ -67,8 +72,12 @@ class Dataset:
 
 
 def mirror_window(w: Window) -> Window:
-    return Window(
-        t0_idx=w.t0_idx,
+    # Only the fields below change under L/R reflection — `replace` forwards
+    # everything else (t0_idx, source_bag, future fields) automatically so adding
+    # to Window can't silently break mirror semantics.
+    # `real_omega` is copied (not flipped) because wheel speeds are sign-symmetric.
+    return replace(
+        w,
         init_state=w.init_state * _MIRROR_INIT_SIGNS,
         cmd_steer=-w.cmd_steer,
         cmd_speed=w.cmd_speed.copy(),
@@ -76,7 +85,7 @@ def mirror_window(w: Window) -> Window:
         real_v_y=-w.real_v_y,
         real_yaw_rate=-w.real_yaw_rate,
         real_a_x=w.real_a_x.copy(),
-        real_omega=w.real_omega.copy(),  # wheel speeds are sign-symmetric under L/R mirror
+        real_omega=w.real_omega.copy(),
         real_pose=w.real_pose * _MIRROR_POSE_SIGNS,
         real_yaw=-w.real_yaw,
         real_beta=-w.real_beta,
@@ -197,4 +206,39 @@ def load_dataset(
         n_candidates=n_candidates,
         n_dropped_low_speed=n_dropped_low_speed,
         n_dropped_nonfinite=n_dropped_nonfinite,
+    )
+
+
+def load_dataset_tagged(npz_path: str, **kwargs) -> Dataset:
+    """``load_dataset`` then stamp the resolved NPZ path into each window's
+    ``source_bag``. Use this (or ``load_datasets``) whenever downstream code
+    needs to group windows by origin (multi-bag validate/study runs)."""
+    ds = load_dataset(npz_path, **kwargs)
+    resolved = str(Path(npz_path).resolve())
+    tagged = [replace(w, source_bag=resolved) for w in ds.windows]
+    return replace(ds, windows=tagged)
+
+
+def load_datasets(npz_paths: list[str], **kwargs) -> Dataset:
+    """Load N bags, tag each window with its source path, concatenate windows
+    into one Dataset. Inputs are sorted by resolved path before loading so
+    window order is deterministic regardless of CLI argument order.
+
+    Weighting is equal-per-window: a 200-window bag contributes 10× more than a
+    20-window bag. All bags share window_length_s / stride_s / min_speed /
+    mirror / dt via **kwargs forwarded to ``load_dataset``.
+    """
+    if not npz_paths:
+        raise ValueError("load_datasets requires at least one path")
+    sorted_paths = sorted({str(Path(p).resolve()) for p in npz_paths})
+    parts = [load_dataset_tagged(p, **kwargs) for p in sorted_paths]
+    dts = {p.dt for p in parts}
+    if len(dts) != 1:
+        raise ValueError(f"Heterogeneous dt across bags: {dts}")
+    return Dataset(
+        windows=[w for p in parts for w in p.windows],
+        dt=parts[0].dt,
+        n_candidates=sum(p.n_candidates for p in parts),
+        n_dropped_low_speed=sum(p.n_dropped_low_speed for p in parts),
+        n_dropped_nonfinite=sum(p.n_dropped_nonfinite for p in parts),
     )

--- a/examples/analysis/sysid/launch_study.sh
+++ b/examples/analysis/sysid/launch_study.sh
@@ -2,9 +2,15 @@
 # Launch a parallel Optuna sysid study.
 #
 # Usage:
-#   ./launch_study.sh <bag.npz> <stage> [num_workers] [trials_per_worker] [base_params.yaml]
+#   ./launch_study.sh <bag.npz|bags.txt> <stage> [num_workers] [trials_per_worker] [base_params.yaml]
 #
-# Total trials = num_workers * trials_per_worker. Each workers logs to a separate wandb run
+# First arg is either a single .npz bag, or a .txt file containing one NPZ
+# path per line (blank lines and `#`-comments ignored). With a .txt file, the
+# study name is derived from the list filename stem, and every worker gets all
+# bags via repeated --bag flags.
+#
+# Total trials = num_workers * trials_per_worker. Each worker logs to a separate
+# wandb run under project 'f1tenth-sysid', grouped by the auto-derived study name.
 # Stage names come from STAGE_SPACES in search_spaces.py.
 #
 # Examples:
@@ -12,9 +18,7 @@
 #   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz vehicle_dyn 4 125
 #   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz stage2 4 250 \
 #       gymkhana/envs/params/f1tenth_std_optuna_stage1.yaml
-#
-# Total trials = num_workers * trials_per_worker. Each worker logs to wandb
-# under project 'f1tenth-sysid', grouped by the auto-derived study name.
+#   ./launch_study.sh examples/analysis/bags/may26_set.txt stage1 4 125
 
 set -euo pipefail
 
@@ -24,20 +28,50 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$REPO_ROOT"
 
 if [[ $# -lt 2 ]]; then
-    echo "Usage: $0 <bag.npz> <stage> [num_workers=4] [trials_per_worker=125] [base_params.yaml]"
+    echo "Usage: $0 <bag.npz|bags.txt> <stage> [num_workers=4] [trials_per_worker=125] [base_params.yaml]"
     exit 1
 fi
 
-BAG="$1"
+BAG_ARG="$1"
 STAGE="$2"
 NUM_WORKERS="${3:-4}"
 TRIALS_PER_WORKER="${4:-125}"
 BASE_PARAMS="${5:-}"
 
-if [[ ! -f "$BAG" ]]; then
-    echo "Error: bag not found: $BAG" >&2
+if [[ ! -f "$BAG_ARG" ]]; then
+    echo "Error: not found: $BAG_ARG" >&2
     exit 1
 fi
+
+# Two input modes: single .npz, or .txt bag-list file (one NPZ per line). The
+# bag-list filename stem becomes the study name so it's both deterministic and
+# meaningful (e.g. `may26_set.txt` -> study name `may26_set_stage1`).
+BAGS=()
+if [[ "$BAG_ARG" == *.txt ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Strip leading/trailing whitespace; skip blanks and `#`-comments.
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        BAGS+=("$line")
+    done < "$BAG_ARG"
+    if [[ ${#BAGS[@]} -eq 0 ]]; then
+        echo "Error: bag-list file is empty: $BAG_ARG" >&2
+        exit 1
+    fi
+    NAME_STEM=$(basename "$BAG_ARG" .txt)
+else
+    BAGS=("$BAG_ARG")
+    NAME_STEM=$(basename "$BAG_ARG" .npz)
+fi
+
+for b in "${BAGS[@]}"; do
+    if [[ ! -f "$b" ]]; then
+        echo "Error: bag not found: $b" >&2
+        exit 1
+    fi
+done
+
 # Source of truth: STAGE_SPACES keys in search_spaces.py.
 VALID_STAGES=$(python -c "from examples.analysis.sysid.search_spaces import STAGE_SPACES; print(' '.join(STAGE_SPACES))")
 if ! [[ " $VALID_STAGES " == *" $STAGE "* ]]; then
@@ -45,11 +79,16 @@ if ! [[ " $VALID_STAGES " == *" $STAGE "* ]]; then
     exit 1
 fi
 
-BAG_STEM=$(basename "$BAG" .npz)
-NAME="${BAG_STEM}_${STAGE}"
+NAME="${NAME_STEM}_${STAGE}"
 TOTAL=$(( NUM_WORKERS * TRIALS_PER_WORKER ))
 
 mkdir -p studies
+
+# Build the repeated `--bag` flags consumed by study.py.
+BAG_FLAGS=()
+for b in "${BAGS[@]}"; do
+    BAG_FLAGS+=(--bag "$b")
+done
 
 EXTRA_ARGS=()
 if [[ -n "$BASE_PARAMS" ]]; then
@@ -57,7 +96,14 @@ if [[ -n "$BASE_PARAMS" ]]; then
 fi
 
 echo "================================================================"
-echo "  bag:               $BAG"
+if [[ ${#BAGS[@]} -eq 1 ]]; then
+    echo "  bag:               ${BAGS[0]}"
+else
+    echo "  bags (${#BAGS[@]}):"
+    for b in "${BAGS[@]}"; do
+        echo "    - $b"
+    done
+fi
 echo "  stage:             $STAGE"
 echo "  workers:           $NUM_WORKERS"
 echo "  trials per worker: $TRIALS_PER_WORKER"
@@ -75,7 +121,7 @@ for ((i=1; i<=NUM_WORKERS; i++)); do
     LOG="studies/${NAME}_w${i}.log"
     echo "[worker $i] logging to $LOG"
     python -m examples.analysis.sysid.study \
-        --bag "$BAG" --stage "$STAGE" --n-trials "$TRIALS_PER_WORKER" \
+        "${BAG_FLAGS[@]}" --stage "$STAGE" --n-trials "$TRIALS_PER_WORKER" \
         --study-name "$NAME" \
         "${EXTRA_ARGS[@]}" \
         > "$LOG" 2>&1 &

--- a/examples/analysis/sysid/launch_study.sh
+++ b/examples/analysis/sysid/launch_study.sh
@@ -14,11 +14,11 @@
 # Stage names come from STAGE_SPACES in search_spaces.py.
 #
 # Examples:
-#   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz stage1
+#   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz steer_lag
 #   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz vehicle_dyn 4 125
-#   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz stage2 4 250 \
-#       gymkhana/envs/params/f1tenth_std_optuna_stage1.yaml
-#   ./launch_study.sh examples/analysis/bags/may26_set.txt stage1 4 125
+#   ./launch_study.sh examples/analysis/bags/rosbag2_2026_05_04-17_54_17_100Hz.npz fine_tune 4 500 \
+#       gymkhana/envs/params/f1tenth_std_optuna_vehicle_dyn.yaml
+#   ./launch_study.sh examples/analysis/bags/may26_set.txt vehicle_dyn 4 125
 
 set -euo pipefail
 
@@ -45,7 +45,7 @@ fi
 
 # Two input modes: single .npz, or .txt bag-list file (one NPZ per line). The
 # bag-list filename stem becomes the study name so it's both deterministic and
-# meaningful (e.g. `may26_set.txt` -> study name `may26_set_stage1`).
+# meaningful (e.g. `may26_set.txt` -> study name `may26_set_vehicle_dyn`).
 BAGS=()
 if [[ "$BAG_ARG" == *.txt ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do

--- a/examples/analysis/sysid/search_spaces.py
+++ b/examples/analysis/sysid/search_spaces.py
@@ -1,7 +1,7 @@
 """Optuna search-space definitions for STD system identification (Phase 3).
 
-Stage-1 / Stage-2 distributions and the param-overlay helper. Bounds are
-locked by the Phase-2 sensitivity analysis — see
+Stage distributions (steer_lag, vehicle_dyn, fine_tune) and the param-overlay
+helper. Bounds are locked by the Phase-2 sensitivity analysis — see
 docs/plan/OPTUNA_SYS_ID_SENSITIVITY_REPORT.md §6 for justifications, and
 docs/plan/OPTUNA_SYS_ID.md for the overall design.
 """
@@ -25,9 +25,6 @@ VEHICLE_DYN: dict[str, BaseDistribution] = {
     "I_y_w": FloatDistribution(low=0.0001, high=0.005),  # nominal 0.0017
     "h_s": FloatDistribution(low=0.02, high=0.09),  # nominal 0.074
     "R_w": FloatDistribution(low=0.04, high=0.06),  # nominal 0.049
-}
-
-STAGE1: dict[str, BaseDistribution] = {
     "a_max": FloatDistribution(low=5.0, high=8.0),  # nominal 6.0
     "tire_p_dx1": FloatDistribution(low=0.1, high=1.5),  # nominal 1.1739
     "tire_p_kx1": FloatDistribution(low=5.0, high=30.0),  # nominal 22.303
@@ -35,23 +32,17 @@ STAGE1: dict[str, BaseDistribution] = {
     "tire_p_ky1": FloatDistribution(low=-30.0, high=-5.0),  # nominal -21.92
 }
 
-STAGE2: dict[str, BaseDistribution] = {
+FINE_TUNE: dict[str, BaseDistribution] = {
     "tire_p_cx1": FloatDistribution(low=1.0, high=1.8),  # nominal 1.6411
     "tire_p_ex1": FloatDistribution(low=-2.1, high=0.99),  # nominal 0.46403
     "tire_p_cy1": FloatDistribution(low=1.0, high=1.8),  # nominal 1.3507
     "tire_p_ey1": FloatDistribution(low=-2.1, high=0.99),  # nominal -0.0074722
-}
-
-STAGE3: dict[str, BaseDistribution] = {
     # longitudinal combined - Fx reduction due to lateral slip α
     "tire_r_bx1": FloatDistribution(low=5.0, high=25.0),  # nominal 13.276
     "tire_r_bx2": FloatDistribution(low=-25.0, high=-5.0),  # nominal -13.778
     # lateral combined - Fy reduction due to longitudinal slip κ
     "tire_r_by1": FloatDistribution(low=3.0, high=15.0),  # nominal 7.1433
     "tire_r_by2": FloatDistribution(low=3.0, high=18.0),  # nominal 9.1916
-}
-
-FINE_TUNE: dict[str, BaseDistribution] = {
     # combined-slip shape & curvature
     "tire_r_cx1": FloatDistribution(low=0.8, high=2.0),  # nominal 1.2568
     "tire_r_ex1": FloatDistribution(low=-1.0, high=0.99),  # nominal 0.65225
@@ -70,9 +61,6 @@ FINE_TUNE: dict[str, BaseDistribution] = {
 STAGE_SPACES: dict[str, dict[str, BaseDistribution]] = {
     "steer_lag": STEER_LAG,
     "vehicle_dyn": VEHICLE_DYN,
-    "stage1": STAGE1,
-    "stage2": STAGE2,
-    "stage3": STAGE3,
     "fine_tune": FINE_TUNE,
 }
 

--- a/examples/analysis/sysid/study.py
+++ b/examples/analysis/sysid/study.py
@@ -3,10 +3,18 @@
 CLI::
 
     python -m examples.analysis.sysid.study \\
-        --bag <path> --stage <name> --n-trials 500 \\
-        [--base-params <yaml>]   # default: SYSID_PARAMS
+        --bag <path> [--bag <path2> ...] --stage <name> --n-trials 500 \\
+        [--base-params <yaml>] [--study-name <name>]   # default base: SYSID_PARAMS
 
 Stage names come from ``STAGE_SPACES`` in ``search_spaces.py``.
+
+Multi-bag: ``--bag`` is repeatable. Bags are sorted by resolved path and their
+windows concatenated into one Dataset (equal-per-window weighting). With N>1
+bags, ``--study-name`` is required (single-bag still auto-derives from the bag
+stem). Provenance is stamped in three places: the output YAML header (one
+``# bag:`` line per bag), ``study.user_attrs["bags"]`` (persists in
+JournalStorage), and the wandb run config (``bags``, ``n_bags``,
+``bag_window_counts``).
 
 Re-running with the same study-name continues an existing study (Optuna's
 ``load_if_exists=True``). For parallelism, launch the same CLI N times in
@@ -21,6 +29,7 @@ import datetime as _dt
 import logging
 import math
 import sys
+from collections import Counter
 from pathlib import Path
 
 import optuna
@@ -31,7 +40,7 @@ from optuna.storages import JournalStorage
 from optuna.storages.journal import JournalFileBackend
 
 import wandb
-from examples.analysis.sysid.dataset import Dataset, load_dataset
+from examples.analysis.sysid.dataset import Dataset, load_datasets
 from examples.analysis.sysid.env import SYSID_PARAMS
 from examples.analysis.sysid.loss import dataset_loss
 from examples.analysis.sysid.rollout import Rollout
@@ -145,11 +154,20 @@ def _load_base_params(override: str | None) -> dict:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="python -m examples.analysis.sysid.study")
-    p.add_argument("--bag", required=True)
+    p.add_argument(
+        "--bag",
+        action="append",
+        required=True,
+        help="Path to a 100Hz NPZ bag. Repeat for multi-bag mode (e.g. --bag A.npz --bag B.npz).",
+    )
     p.add_argument("--stage", required=True, choices=tuple(STAGE_SPACES.keys()))
     p.add_argument("--n-trials", type=int, default=500)
     p.add_argument("--base-params", default=None, help="YAML to load (default: SYSID_PARAMS)")
-    p.add_argument("--study-name", default=None, help="Default: <bag_stem>_<stage>")
+    p.add_argument(
+        "--study-name",
+        default=None,
+        help="Default: <bag_stem>_<stage> (single-bag only); required when multiple --bag are given.",
+    )
     p.add_argument(
         "--storage", default=None, help="Path to the Optuna journal file. Default: <repo>/studies/<study_name>.journal"
     )
@@ -167,11 +185,17 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s: %(message)s")
     args = parse_args(argv)
 
-    bag = Path(args.bag).resolve()
-    if not bag.exists():
-        raise SystemExit(f"Bag not found: {bag}")
+    # Sort + dedup so CLI argument order doesn't change behavior (CMA-ES is seed-driven;
+    # floating-point reductions aren't associative, so window order matters in the low bits).
+    bags = sorted({Path(b).resolve() for b in args.bag})
+    for b in bags:
+        if not b.exists():
+            raise SystemExit(f"Bag not found: {b}")
 
-    name = args.study_name or f"{bag.stem}_{args.stage}"
+    if len(bags) > 1 and args.study_name is None:
+        raise SystemExit("--study-name is required when multiple --bag are given")
+    name = args.study_name or f"{bags[0].stem}_{args.stage}"
+
     journal_path = (
         Path(args.storage).resolve()
         if args.storage is not None
@@ -186,11 +210,23 @@ def main(argv: list[str] | None = None) -> int:
     space = STAGE_SPACES[args.stage]
     base_params = _load_base_params(args.base_params)
 
-    _LOG.info("Loading dataset from %s (mirror=%s)", bag, args.mirror)
-    dataset = load_dataset(str(bag), mirror=args.mirror)
-    _LOG.info("Dataset: %d windows", len(dataset.windows))
+    _LOG.info("Loading %d bag(s) (mirror=%s)", len(bags), args.mirror)
+    for b in bags:
+        _LOG.info("  bag: %s", b)
+    dataset = load_datasets([str(b) for b in bags], mirror=args.mirror)
+    # Each window carries source_bag (stamped by load_datasets) — group for per-bag visibility.
+    bag_window_counts = {b.stem: 0 for b in bags}
+    for path, count in Counter(w.source_bag for w in dataset.windows).items():
+        bag_window_counts[Path(path).stem] = count
+    for stem, count in bag_window_counts.items():
+        _LOG.info("  bag %s: %d windows", stem, count)
+    _LOG.info("Dataset: %d windows total across %d bag(s)", len(dataset.windows), len(bags))
     _LOG.info("Study: name=%s journal=%s", name, journal_path)
     study = build_study(name, journal_path, SEED)
+    # Stamp provenance into the journal so the study is self-describing even
+    # without the wandb run or the output YAML alongside.
+    study.set_user_attr("bags", [str(b) for b in bags])
+    study.set_user_attr("stage", args.stage)
 
     wandb_init_kwargs = dict(
         project=WANDB_PROJECT,
@@ -198,7 +234,9 @@ def main(argv: list[str] | None = None) -> int:
         job_type=f"stage{args.stage}",
         dir=str(REPO_ROOT),  # write wandb/ at repo root, not CWD
         config={
-            "bag": bag.stem,
+            "bags": [b.stem for b in bags],
+            "n_bags": len(bags),
+            "bag_window_counts": bag_window_counts,
             "stage": args.stage,
             "n_trials": args.n_trials,
             "seed": SEED,
@@ -224,10 +262,16 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     timestamp = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+    # One `# bag:` line per bag — six-month-from-now-you finds this YAML and
+    # immediately knows what produced it without needing wandb or the journal.
+    bag_header_lines = "".join(f"# bag: {b}\n" for b in bags)
+    # Stage 2 typically loads Stage 1's YAML — record which one so the chain is auditable.
+    base_params_label = str(Path(args.base_params).resolve()) if args.base_params else "SYSID_PARAMS (env.py default)"
     header = (
         f"# Generated by examples/analysis/sysid/study.py @ {timestamp}\n"
-        f"# bag: {bag}\n"
+        f"{bag_header_lines}"
         f"# stage: {args.stage}\n"
+        f"# base_params: {base_params_label}\n"
         f"# study: {name} (journal: {journal_path})\n"
         f"# seed: {SEED}\n"
         f"# n_trials: {len(study.trials)}\n"

--- a/examples/analysis/sysid/study.py
+++ b/examples/analysis/sysid/study.py
@@ -33,13 +33,13 @@ from collections import Counter
 from pathlib import Path
 
 import optuna
+import wandb
 import yaml
 from optuna.distributions import BaseDistribution, FloatDistribution
 from optuna.samplers import CmaEsSampler
 from optuna.storages import JournalStorage
 from optuna.storages.journal import JournalFileBackend
 
-import wandb
 from examples.analysis.sysid.dataset import Dataset, load_datasets
 from examples.analysis.sysid.env import SYSID_PARAMS
 from examples.analysis.sysid.loss import dataset_loss

--- a/examples/analysis/sysid/validate.py
+++ b/examples/analysis/sysid/validate.py
@@ -1,18 +1,39 @@
 """Single-call validation/debugging entry point for the STD sysid pipeline.
 
-Given a 100 Hz Vicon NPZ bag and a parameter set, produces:
+Given one or more 100 Hz Vicon NPZ bags and a parameter set, produces sim-vs-real
+plots plus a metrics.txt whose `balanced CHANNEL_COEFFS` block is meant to be
+copy-pasted into `loss.py` to balance channel contributions before launching a
+study. The aggregated loss matches what `study.py` minimizes (equal-per-window
+across all bags), so coefficients tuned here transfer directly.
 
+Single-bag layout (flat, default for one --bag):
   - dataset_overview.png            — windowed bag signals
-  - dataset_overview_mirror.png     — same, mirrored windows (omitted with --no-mirror)
+  - dataset_overview_mirror.png     — same, mirrored windows (with --mirror)
   - rollout_overlay.png             — sim vs real, one segment per window
   - metrics.txt                     — window counts, drop counts, total + per-channel loss
+
+Multi-bag layout (--out-dir required, one subdir per bag):
+  <out-dir>/
+    metrics.txt                     — aggregated total + per-channel + per-bag raw_MSE table
+    <bag_stem_A>/
+      dataset_overview.png
+      dataset_overview_mirror.png   (with --mirror)
+      rollout_overlay.png
+      metrics.txt                   — per-bag breakdown
+    <bag_stem_B>/
+      ...
+
+The per-bag raw_MSE block in the aggregated metrics.txt flags heterogeneous bags
+whose union loss would be a compromise — large variance on a channel means the
+balanced coefficients are averaging over disagreeing bags.
 
 To compare two parameter sets, run twice with different `--params` /
 `--out-dir` and diff `metrics.txt`. Replaces the prior split between
 `compare_loss.py` and the `__main__` blocks of `dataset.py` / `rollout.py`.
 
-Example:
-  python -m examples.analysis.sysid.validate --bag bag.npz [--params tuned.yaml] [--mirror] [--out-dir DIR]
+Examples:
+  python -m examples.analysis.sysid.validate --bag bag.npz [--params tuned.yaml] [--mirror]
+  python -m examples.analysis.sysid.validate --bag A.npz --bag B.npz --out-dir DIR
 """
 
 from __future__ import annotations
@@ -25,7 +46,7 @@ import numpy as np
 import yaml
 from scipy.signal import savgol_filter
 
-from examples.analysis.sysid.dataset import CHANNELS, Dataset, Window, load_dataset
+from examples.analysis.sysid.dataset import CHANNELS, Dataset, Window, load_dataset_tagged
 from examples.analysis.sysid.env import SYSID_PARAMS
 from examples.analysis.sysid.loss import CHANNEL_COEFFS, window_loss
 from examples.analysis.sysid.rollout import Rollout
@@ -223,15 +244,18 @@ def _check_yaw_continuity(
     return failures
 
 
-def _format_continuity_lines(failures: list[tuple[int, float, float]]) -> list[str]:
+def _format_continuity_lines(failures: list[tuple[str, int, float, float]]) -> list[str]:
+    """Format yaw-continuity failures. Each entry is `(bag_stem, t0_idx, max_sim, max_real)`;
+    the `bag_stem` tag is informational in single-bag mode and load-bearing in multi-bag mode.
+    """
     if not failures:
         return ["yaw_continuity: PASS"]
     lines = [
         f"WARN: yaw continuity check failed for {len(failures)} window(s) "
         "(per-step Δyaw > π/2; overlay plot may mislead, loss math still correct):"
     ]
-    for t0_idx, max_sim, max_real in failures:
-        lines.append(f"  t0_idx={t0_idx} max_sim_step={max_sim:.4f} max_real_step={max_real:.4f}")
+    for bag_stem, t0_idx, max_sim, max_real in failures:
+        lines.append(f"  bag={bag_stem} t0_idx={t0_idx} max_sim_step={max_sim:.4f} max_real_step={max_real:.4f}")
     return lines
 
 
@@ -474,21 +498,60 @@ def _format_channel_table(per_channel: dict[str, float]) -> list[str]:
     return lines
 
 
+def _format_per_bag_raw_mse_table(per_bag_per_channel: dict[str, dict[str, float]]) -> list[str]:
+    """Per-bag raw MSE per channel — sanity-check that bags agree.
+
+    raw_MSE = contribution / coeff (matches `_format_channel_table`). Large
+    variance across bags on a channel means the bag set is heterogeneous enough
+    that the union loss is a compromise; consider dropping or reweighting an
+    outlier bag before relying on `balanced CHANNEL_COEFFS`.
+    """
+    # Sort explicitly so column order doesn't depend on caller's dict insertion order.
+    bag_stems = sorted(per_bag_per_channel.keys())
+    col_w = max(12, max(len(s) for s in bag_stems) + 2)
+    lines = ["per-bag raw_MSE (sanity check — large variance across bags = bag selection issue):"]
+    header = f"  {'channel':<10}" + "".join(f"{s:>{col_w}}" for s in bag_stems)
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for ch in CHANNELS:
+        coeff = CHANNEL_COEFFS[ch]
+        row = f"  {ch:<10}"
+        for stem in bag_stems:
+            contrib = per_bag_per_channel[stem].get(ch, float("nan"))
+            if coeff != 0.0:
+                raw = contrib / coeff
+                row += f"{raw:>{col_w}.6f}"
+            else:
+                row += f"{'n/a':>{col_w}}"
+        lines.append(row)
+    return lines
+
+
 def _write_metrics(
     out_path: str,
     *,
-    bag: Path,
+    bags: list[Path],
     params_source: str,
     args: argparse.Namespace,
     dataset: Dataset,
     total_loss: float,
     per_channel: dict[str, float],
-    continuity_failures: list[tuple[int, float, float]],
+    continuity_failures: list[tuple[str, int, float, float]],
+    per_bag_per_channel: dict[str, dict[str, float]] | None = None,
 ) -> None:
+    """Write `metrics.txt`. ``bags`` is the list scoping this report (one entry
+    for a per-bag file, all bags for the aggregated file). ``per_bag_per_channel``
+    enables the raw_MSE diagnostic block — only meaningful when N>1, ignored
+    otherwise.
+    """
     n_originals = sum(not w.is_mirrored for w in dataset.windows)
     n_mirrored = len(dataset.windows) - n_originals
+    if len(bags) == 1:
+        header_lines = [f"bag: {bags[0]}"]
+    else:
+        header_lines = ["bags:", *(f"  - {b}" for b in bags)]
     lines = [
-        f"bag: {bag}",
+        *header_lines,
         f"params: {params_source}",
         f"window_length_s: {args.window_length_s}",
         f"stride_s: {args.stride_s}",
@@ -506,9 +569,10 @@ def _write_metrics(
         f"total_loss: {total_loss:.6f}",
         "",
         *_format_channel_table(per_channel),
-        "",
-        *_format_continuity_lines(continuity_failures),
     ]
+    if per_bag_per_channel is not None and len(per_bag_per_channel) > 1:
+        lines.extend(["", *_format_per_bag_raw_mse_table(per_bag_per_channel)])
+    lines.extend(["", *_format_continuity_lines(continuity_failures)])
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     with open(out_path, "w") as f:
         f.write("\n".join(lines) + "\n")
@@ -523,7 +587,12 @@ def _load_params(path: str | None) -> tuple[dict, str]:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="python -m examples.analysis.sysid.validate")
-    p.add_argument("--bag", required=True, help="Path to 100Hz NPZ bag")
+    p.add_argument(
+        "--bag",
+        action="append",
+        required=True,
+        help="Path to a 100Hz NPZ bag. Repeat for multi-bag mode (e.g. --bag A.npz --bag B.npz).",
+    )
     p.add_argument("--params", default=None, help="YAML param file (default: SYSID_PARAMS)")
     p.add_argument("--window-length-s", type=float, default=1.5)
     p.add_argument("--stride-s", type=float, default=0.5)
@@ -535,79 +604,148 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=False,
         help="Include mirrored windows (default: False, matches study.py)",
     )
-    p.add_argument("--out-dir", default=None, help="Default: figures/analysis/sysid/<bag_stem>/")
+    p.add_argument(
+        "--out-dir",
+        default=None,
+        help="Default: figures/analysis/sysid/<bag_stem>/ (single-bag); required for multi-bag.",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    bag = Path(args.bag).resolve()
-    if not bag.exists():
-        raise SystemExit(f"Bag not found: {bag}")
+    # Sort + dedup so CLI argument order doesn't change output, and repeats are harmless.
+    bags = sorted({Path(b).resolve() for b in args.bag})
+    for b in bags:
+        if not b.exists():
+            raise SystemExit(f"Bag not found: {b}")
+    multi = len(bags) > 1
+    if multi and args.out_dir is None:
+        raise SystemExit("--out-dir is required when multiple --bag are given")
 
     params, params_source = _load_params(args.params)
-    out_dir = Path(args.out_dir).resolve() if args.out_dir else Path("figures") / "analysis" / "sysid" / bag.stem
+    if args.out_dir:
+        out_dir = Path(args.out_dir).resolve()
+    else:
+        out_dir = (Path("figures") / "analysis" / "sysid" / bags[0].stem).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    dataset = load_dataset(
-        str(bag),
-        window_length_s=args.window_length_s,
-        stride_s=args.stride_s,
-        min_speed=args.min_speed,
-        mirror=args.mirror,
-    )
-    n_originals = sum(not w.is_mirrored for w in dataset.windows)
-    n_mirrored = len(dataset.windows) - n_originals
-    print(
-        f"loaded {len(dataset.windows)} windows from {bag} "
-        f"(originals={n_originals}, mirrored={n_mirrored}, "
-        f"dropped_low_speed={dataset.n_dropped_low_speed}, "
-        f"dropped_nonfinite={dataset.n_dropped_nonfinite}, "
-        f"candidates={dataset.n_candidates})"
+    # Per-bag loads carry source_bag stamping + their own n_candidates/drop stats.
+    per_bag_datasets: list[tuple[Path, Dataset]] = []
+    for bp in bags:
+        ds = load_dataset_tagged(
+            str(bp),
+            window_length_s=args.window_length_s,
+            stride_s=args.stride_s,
+            min_speed=args.min_speed,
+            mirror=args.mirror,
+        )
+        per_bag_datasets.append((bp, ds))
+
+    dts = {ds.dt for _, ds in per_bag_datasets}
+    if len(dts) != 1:
+        raise ValueError(f"Heterogeneous dt across bags: {dts}")
+
+    # Combined view scoped to the aggregated metrics file. Matches what study.py
+    # builds via load_datasets() — equal-per-window across all bags.
+    combined = Dataset(
+        windows=[w for _, ds in per_bag_datasets for w in ds.windows],
+        dt=per_bag_datasets[0][1].dt,
+        n_candidates=sum(ds.n_candidates for _, ds in per_bag_datasets),
+        n_dropped_low_speed=sum(ds.n_dropped_low_speed for _, ds in per_bag_datasets),
+        n_dropped_nonfinite=sum(ds.n_dropped_nonfinite for _, ds in per_bag_datasets),
     )
 
-    _plot_dataset_overview(dataset, str(bag), str(out_dir / "dataset_overview.png"), mirror=False)
-    print(f"saved {out_dir / 'dataset_overview.png'}")
-    if args.mirror:
-        _plot_dataset_overview(dataset, str(bag), str(out_dir / "dataset_overview_mirror.png"), mirror=True)
-        print(f"saved {out_dir / 'dataset_overview_mirror.png'}")
+    for bp, ds in per_bag_datasets:
+        n_orig = sum(not w.is_mirrored for w in ds.windows)
+        n_mir = len(ds.windows) - n_orig
+        print(
+            f"loaded {len(ds.windows)} windows from {bp} "
+            f"(originals={n_orig}, mirrored={n_mir}, "
+            f"dropped_low_speed={ds.n_dropped_low_speed}, "
+            f"dropped_nonfinite={ds.n_dropped_nonfinite}, "
+            f"candidates={ds.n_candidates})"
+        )
 
-    originals = [w for w in dataset.windows if not w.is_mirrored]
-    warmup_steps = int(round(args.warmup_s / dataset.dt))
-    min_window_len = min(len(w.real_v_x) for w in dataset.windows)
+    warmup_steps = int(round(args.warmup_s / combined.dt))
+    min_window_len = min(len(w.real_v_x) for w in combined.windows)
     if warmup_steps >= min_window_len:
         raise SystemExit(
-            f"--warmup-s={args.warmup_s} ({warmup_steps} steps at dt={dataset.dt}) "
+            f"--warmup-s={args.warmup_s} ({warmup_steps} steps at dt={combined.dt}) "
             f"leaves no scored samples (shortest window has {min_window_len} samples)"
         )
+
     totals: list[float] = []
     accum: dict[str, list[float]] = {ch: [] for ch in CHANNELS}
+    per_bag_per_channel_mean: dict[str, dict[str, float]] = {}
+    all_continuity_failures: list[tuple[str, int, float, float]] = []
 
     with Rollout(params=params) as rollout:
-        # One sim per original window — traces feed both the overlay and the loss.
-        # Mirrored windows still need their own pass through `rollout.run`.
-        sim_traces = [rollout.run_debug(w) for w in originals]
-        _plot_rollout_overlay(
-            dataset, originals, sim_traces, str(bag), str(out_dir / "rollout_overlay.png"), warmup_s=args.warmup_s
-        )
-        print(f"saved {out_dir / 'rollout_overlay.png'}")
+        for bp, ds in per_bag_datasets:
+            # multi=False keeps the legacy flat layout for single-bag callers.
+            bag_subdir = (out_dir / bp.stem) if multi else out_dir
+            bag_subdir.mkdir(parents=True, exist_ok=True)
 
-        continuity_failures = _check_yaw_continuity(originals, sim_traces)
-        for line in _format_continuity_lines(continuity_failures):
-            print(line)
+            _plot_dataset_overview(ds, str(bp), str(bag_subdir / "dataset_overview.png"), mirror=False)
+            print(f"saved {bag_subdir / 'dataset_overview.png'}")
+            if args.mirror:
+                _plot_dataset_overview(ds, str(bp), str(bag_subdir / "dataset_overview_mirror.png"), mirror=True)
+                print(f"saved {bag_subdir / 'dataset_overview_mirror.png'}")
 
-        for w, tr in zip(originals, sim_traces):
-            total, per_ch = window_loss(_debug_to_loss_sim(tr), w, CHANNEL_COEFFS, warmup_steps)
-            totals.append(total)
+            originals = [w for w in ds.windows if not w.is_mirrored]
+            # One sim per original window — traces feed both the overlay and the loss.
+            # Mirrored windows still need their own pass through `rollout.run`.
+            sim_traces = [rollout.run_debug(w) for w in originals]
+            _plot_rollout_overlay(
+                ds,
+                originals,
+                sim_traces,
+                str(bp),
+                str(bag_subdir / "rollout_overlay.png"),
+                warmup_s=args.warmup_s,
+            )
+            print(f"saved {bag_subdir / 'rollout_overlay.png'}")
+
+            bag_failures = [(bp.stem, t0, ms, mr) for (t0, ms, mr) in _check_yaw_continuity(originals, sim_traces)]
+            for line in _format_continuity_lines(bag_failures):
+                print(line)
+            all_continuity_failures.extend(bag_failures)
+
+            bag_totals: list[float] = []
+            bag_accum: dict[str, list[float]] = {ch: [] for ch in CHANNELS}
+            for w, tr in zip(originals, sim_traces):
+                total, per_ch = window_loss(_debug_to_loss_sim(tr), w, CHANNEL_COEFFS, warmup_steps)
+                bag_totals.append(total)
+                for ch in CHANNELS:
+                    bag_accum[ch].append(per_ch[ch])
+            for w in ds.windows:
+                if not w.is_mirrored:
+                    continue
+                total, per_ch = window_loss(rollout.run(w), w, CHANNEL_COEFFS, warmup_steps)
+                bag_totals.append(total)
+                for ch in CHANNELS:
+                    bag_accum[ch].append(per_ch[ch])
+
+            bag_total_loss = float(np.mean(bag_totals))
+            bag_per_channel = {ch: float(np.mean(bag_accum[ch])) for ch in CHANNELS}
+            per_bag_per_channel_mean[bp.stem] = bag_per_channel
+
+            if multi:
+                _write_metrics(
+                    str(bag_subdir / "metrics.txt"),
+                    bags=[bp],
+                    params_source=params_source,
+                    args=args,
+                    dataset=ds,
+                    total_loss=bag_total_loss,
+                    per_channel=bag_per_channel,
+                    continuity_failures=bag_failures,
+                )
+                print(f"saved {bag_subdir / 'metrics.txt'}")
+
+            totals.extend(bag_totals)
             for ch in CHANNELS:
-                accum[ch].append(per_ch[ch])
-        for w in dataset.windows:
-            if not w.is_mirrored:
-                continue
-            total, per_ch = window_loss(rollout.run(w), w, CHANNEL_COEFFS, warmup_steps)
-            totals.append(total)
-            for ch in CHANNELS:
-                accum[ch].append(per_ch[ch])
+                accum[ch].extend(bag_accum[ch])
 
     total_loss = float(np.mean(totals))
     per_channel = {ch: float(np.mean(accum[ch])) for ch in CHANNELS}
@@ -620,13 +758,14 @@ def main(argv: list[str] | None = None) -> int:
     metrics_path = out_dir / "metrics.txt"
     _write_metrics(
         str(metrics_path),
-        bag=bag,
+        bags=bags,
         params_source=params_source,
         args=args,
-        dataset=dataset,
+        dataset=combined,
         total_loss=total_loss,
         per_channel=per_channel,
-        continuity_failures=continuity_failures,
+        continuity_failures=all_continuity_failures,
+        per_bag_per_channel=per_bag_per_channel_mean if multi else None,
     )
     print(f"saved {metrics_path}")
     return 0

--- a/gymkhana/envs/gymkhana_env.py
+++ b/gymkhana/envs/gymkhana_env.py
@@ -561,6 +561,20 @@ class GKEnv(gym.Env):
         return load_params("f1tenth_std")
 
     @classmethod
+    def f1tenth_std_new_tire_covers_params(cls) -> dict:
+        """Return STD-model parameters for the 1/10th scale F1TENTH car fitted with
+        new slippery 3D-printed tire covers.
+
+        Same structure as :meth:`f1tenth_std_vehicle_params` but with re-fitted
+        PAC2002 tyre coefficients (lower friction peaks) from a fresh sysid run.
+        See ``gymkhana/envs/params/f1tenth_std_new_tire_covers.yaml``.
+
+        Returns:
+            Complete parameter dictionary for the STD model with new tire covers.
+        """
+        return load_params("f1tenth_std_new_tire_covers")
+
+    @classmethod
     def f1tenth_stp_vehicle_params(cls) -> dict:
         """Return default parameters for the 1/10th scale F1TENTH car (STP model).
 

--- a/gymkhana/envs/params/f1tenth_std.yaml
+++ b/gymkhana/envs/params/f1tenth_std.yaml
@@ -3,7 +3,7 @@
 # =========================
 # VEHICLE PARAMS
 # =========================
-m: 3.58           # [kg] total mass - measured accurately using a scale
+m: 3.633           # [kg] total mass - measured accurately using a scale
 lf: 0.176         # [m] distance from center of gravity to front axle - measured accurately by balancing the car about the CoG
 lr: 0.15          # [m] distance from center of gravity to rear axle - measured accurately by balancing the car about the CoG
 I_z: 0.0897       # [kg * m^2] moment of inertia for entire mass about z axis - currently copied from f1tenth_gym

--- a/gymkhana/envs/params/f1tenth_std_new_tire_covers.yaml
+++ b/gymkhana/envs/params/f1tenth_std_new_tire_covers.yaml
@@ -1,12 +1,12 @@
-# Parameters for the 1/10th scale F1TENTH car (STD model)
+# Parameters for the 1/10th scale F1TENTH car (STD model) with new slippery 3D-printed tire covers
 
 # =========================
 # VEHICLE PARAMS
 # =========================
-m: 3.58           # [kg] total mass - measured accurately using a scale
+m: 3.633           # [kg] total mass - measured accurately using a scale
 lf: 0.176         # [m] distance from center of gravity to front axle - measured accurately by balancing the car about the CoG
 lr: 0.15          # [m] distance from center of gravity to rear axle - measured accurately by balancing the car about the CoG
-I_z: 0.0897       # [kg * m^2] moment of inertia for entire mass about z axis - currently copied from f1tenth_gym
+I_z: 0.0806       # [kg * m^2] moment of inertia for entire mass about z axis - currently copied from f1tenth_gym
 s_min: -0.52      # [rad] minimum steering angle - originally -0.4189
 s_max: 0.52       # [rad] maximum steering angle - originally 0.4189
 sv_min: -6.5531   # [rad/s] minimum steering speed
@@ -14,14 +14,14 @@ sv_max: 6.5531    # [rad/s] maximum steering speed
 T_steer: 0.081531 # [s] Steering actuator time constant; 0/omitted gives bang-bang, else first-order lag - 
 v_switch: 7.319   # [m/s] velocity threshold above which peak accl scales down inversely with speed
                   # models the fact that at high speed, the powertrain can no longer produce wheelspin/peak torque
-a_max: 7.3614     # [m/s^2] maximum acceleration (-a_max is maximum braking) - originally 9.51
+a_max: 5.0819     # [m/s^2] maximum acceleration (-a_max is maximum braking) - originally 9.51
 v_min: -5.0       # [m/s] minimum velocity
 v_max: 20.0       # [m/s] maximum velocity
 width: 0.31       # [m] vehicle width
 length: 0.58      # [m] vehicle length
-h_s: 0.0898       # [m] height of center of gravity - copied from ETH simulator
-R_w: 0.0434       # [m] effective tire radius - estimated by me to be 49 mm which is 0.049 m
-I_y_w: 0.0012016  # [kg m^2] wheel inertia -
+h_s: 0.0200       # [m] height of center of gravity - copied from ETH simulator
+R_w: 0.0466       # [m] effective tire radius
+I_y_w: 0.0043832  # [kg m^2] wheel inertia -
 T_sb: 0.5         # [no units] torque split of brakes (percent of torque sent to front axle) - AWD, assuming even front/back
 T_se: 0.5         # [no units] torque split of engine (percent of torque sent to front axle) - AWD, assuming even front/back
 
@@ -36,39 +36,39 @@ T_se: 0.5         # [no units] torque split of engine (percent of torque sent to
 # Sysid priority: peaks & stiffness (d*, k*) > combined slopes (r_b*) > shifts/curvature
 
 # Pure-slip longitudinal (formula_longitudinal)
-tire_p_dx1: 0.7304       # D: peak longitudinal friction μ_x - dominant long. param
-tire_p_kx1: 16.7905      # K→B: longitudinal slip stiffness - secondary long. para,
-tire_p_cx1: 1.1952       # C: shape of Fx curve - tertiary long. param
-tire_p_ex1: -0.0959      # E: curvature of Fx peak - tertiary long. param
+tire_p_dx1: 0.3080       # D: peak longitudinal friction μ_x - dominant long. param
+tire_p_kx1: 11.6818      # K→B: longitudinal slip stiffness - secondary long. para,
+tire_p_cx1: 1.0156       # C: shape of Fx curve - tertiary long. param
+tire_p_ex1: -1.1946      # E: curvature of Fx peak - tertiary long. param
 tire_p_hx1: 0.0012297    # Sh: horizontal shift
 tire_p_vx1: -8.8098e-06  # Sv: vertical shift
 
 # Pure-slip lateral (formula_lateral)
-tire_p_dy1: 0.2903       # D: peak lateral friction μ_y - dominant lat. param
-tire_p_ky1: -21.1134     # K→B: cornering stiffness - secondary lat. param
-tire_p_cy1: 1.1170       # C: shape of Fy curve - tertiary lat. param
-tire_p_ey1: 0.7310       # E: curvature of Fy peak - tertiary lat. param
+tire_p_dy1: 0.3942       # D: peak lateral friction μ_y - dominant lat. param
+tire_p_ky1: -5.1624      # K→B: cornering stiffness - secondary lat. param
+tire_p_cy1: 1.0008       # C: shape of Fy curve - tertiary lat. param
+tire_p_ey1: -1.1384      # E: curvature of Fy peak - tertiary lat. param
 tire_p_hy1: 0.0026747    # Sh: horizontal shift
 tire_p_vy1: 0.037318     # Sv: vertical shift
 
 # Combined-slip longitudinal reduction (formula_longitudinal_comb)
-tire_r_bx1: 9.4634       # B: base slope of Fx reduction vs α
-tire_r_bx2: -19.2474     # B: slope variation with κ
-tire_r_cx1: 1.3723       # C: shape of Fx reduction
-tire_r_ex1: 0.4564       # E: curvature of Fx reduction
+tire_r_bx1: 17.8457      # B: base slope of Fx reduction vs α
+tire_r_bx2: -10.8683     # B: slope variation with κ
+tire_r_cx1: 1.2571       # C: shape of Fx reduction
+tire_r_ex1: -0.1795      # E: curvature of Fx reduction
 tire_r_hx1: 0.0050722    # Sh: shift of Fx reduction
 
 # Combined-slip lateral reduction + κ-induced side force Svyk (formula_lateral_comb)
-tire_r_by1: 14.2841      # B: base slope of Fy reduction vs κ
-tire_r_by2: 7.2795       # B: slope variation with α
-tire_r_by3: 0.0513       # B: α-shift in slope
-tire_r_cy1: 1.1433       # C: shape of Fy reduction
-tire_r_ey1: 0.8369       # E: curvature of Fy reduction
+tire_r_by1: 10.0222      # B: base slope of Fy reduction vs κ
+tire_r_by2: 11.7702      # B: slope variation with α
+tire_r_by3: -0.0067      # B: α-shift in slope
+tire_r_cy1: 1.1449       # C: shape of Fy reduction
+tire_r_ey1: 0.5074       # E: curvature of Fy reduction
 tire_r_hy1: 5.7448e-06   # Sh: shift of Fy reduction
-tire_r_vy1: 0.0429       # Svyk: base magnitude of κ-induced side force
-tire_r_vy4: 13.9457      # Svyk: variation with α
-tire_r_vy5: 1.5620       # Svyk: variation with κ
-tire_r_vy6: -11.3374     # Svyk: variation with atan(κ)
+tire_r_vy1: -0.0641      # Svyk: base magnitude of κ-induced side force
+tire_r_vy4: 18.9953      # Svyk: variation with α
+tire_r_vy5: 1.3903       # Svyk: variation with κ
+tire_r_vy6: -18.4337     # Svyk: variation with atan(κ)
 
 # Dead: camber terms (single-track has no roll DOF, gamma=0 at all call sites)
 tire_p_dx3: 0            # μ_x variation with camber²

--- a/tests/sysid/test_dataset.py
+++ b/tests/sysid/test_dataset.py
@@ -8,6 +8,7 @@ fast and have known ground truth.
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -15,6 +16,8 @@ from scipy.signal import savgol_filter
 
 from examples.analysis.sysid.dataset import (
     load_dataset,
+    load_dataset_tagged,
+    load_datasets,
     mirror_window,
 )
 from examples.analysis.sysid.env import SYSID_PARAMS
@@ -324,3 +327,87 @@ def test_window_is_frozen(straight_npz):
 def test_dataset_dt_set(straight_npz):
     ds = load_dataset(straight_npz, mirror=False, dt=0.01)
     assert ds.dt == 0.01
+
+
+# -- source_bag tagging + multi-bag aggregation --
+
+
+def test_load_dataset_default_source_bag_empty(straight_npz):
+    """load_dataset leaves source_bag empty so existing single-bag callers
+    (sensitivity.py, study.py single-bag mode) are unaffected.
+    """
+    ds = load_dataset(straight_npz, mirror=False)
+    assert all(w.source_bag == "" for w in ds.windows)
+
+
+def test_load_dataset_tagged_stamps_resolved_path(straight_npz):
+    ds = load_dataset_tagged(straight_npz, mirror=False)
+    expected = str(Path(straight_npz).resolve())
+    assert all(w.source_bag == expected for w in ds.windows)
+
+
+def test_mirror_window_propagates_source_bag(asymmetric_npz):
+    ds = load_dataset_tagged(asymmetric_npz, mirror=False)
+    w = ds.windows[0]
+    m = mirror_window(w)
+    assert m.source_bag == w.source_bag
+
+
+@pytest.fixture
+def two_bags(tmp_path):
+    a = tmp_path / "a.npz"
+    b = tmp_path / "b.npz"
+    _make_npz(str(a), speed=1.0)
+    _make_npz(str(b), speed=1.5)
+    return str(a), str(b)
+
+
+def test_load_datasets_concat_windows(two_bags):
+    a, b = two_bags
+    da = load_dataset(a, mirror=False)
+    db = load_dataset(b, mirror=False)
+    combined = load_datasets([a, b], mirror=False)
+    assert len(combined.windows) == len(da.windows) + len(db.windows)
+    assert combined.n_candidates == da.n_candidates + db.n_candidates
+    assert combined.n_dropped_low_speed == da.n_dropped_low_speed + db.n_dropped_low_speed
+    assert combined.n_dropped_nonfinite == da.n_dropped_nonfinite + db.n_dropped_nonfinite
+    assert combined.dt == da.dt
+
+
+def test_load_datasets_tags_source_bag(two_bags):
+    a, b = two_bags
+    combined = load_datasets([a, b], mirror=False)
+    a_res = str(Path(a).resolve())
+    b_res = str(Path(b).resolve())
+    sources = {w.source_bag for w in combined.windows}
+    assert sources == {a_res, b_res}
+
+
+def test_load_datasets_sorts_inputs_deterministic(two_bags):
+    """CLI order must not affect window order — sort by resolved path internally."""
+    a, b = two_bags
+    forward = load_datasets([a, b], mirror=False)
+    reverse = load_datasets([b, a], mirror=False)
+    assert [w.source_bag for w in forward.windows] == [w.source_bag for w in reverse.windows]
+    assert [w.t0_idx for w in forward.windows] == [w.t0_idx for w in reverse.windows]
+
+
+def test_load_datasets_deduplicates(two_bags):
+    """Passing the same path twice loads it once (sorted dedup via set)."""
+    a, _ = two_bags
+    single = load_datasets([a], mirror=False)
+    doubled = load_datasets([a, a], mirror=False)
+    assert len(single.windows) == len(doubled.windows)
+
+
+def test_load_datasets_empty_raises():
+    with pytest.raises(ValueError, match="at least one"):
+        load_datasets([], mirror=False)
+
+
+def test_load_datasets_mirror_passthrough(two_bags):
+    """`mirror=True` kwarg forwards into each load_dataset call."""
+    a, b = two_bags
+    no_mirror = load_datasets([a, b], mirror=False)
+    with_mirror = load_datasets([a, b], mirror=True)
+    assert len(with_mirror.windows) == 2 * len(no_mirror.windows)

--- a/tests/sysid/test_search_spaces.py
+++ b/tests/sysid/test_search_spaces.py
@@ -11,11 +11,11 @@ from optuna.distributions import FloatDistribution
 
 from examples.analysis.sysid.env import SYSID_PARAMS
 from examples.analysis.sysid.search_spaces import (
-    STAGE1,
-    STAGE2,
+    FINE_TUNE,
     STAGE_SPACES,
     STEER_LAG,
     SYMMETRIC_PAIRS,
+    VEHICLE_DYN,
     apply_trial_params,
 )
 from examples.analysis.sysid.sensitivity import FROZEN_PARAMS
@@ -28,7 +28,7 @@ def test_search_keys_exist_in_sysid_params():
 
 
 def test_stages_disjoint():
-    assert set(STAGE1) & set(STAGE2) == set()
+    assert set(VEHICLE_DYN) & set(FINE_TUNE) == set()
 
 
 def test_stages_disjoint_with_frozen():
@@ -60,7 +60,7 @@ def test_apply_trial_params_non_mutating():
 
 def test_apply_trial_params_overlays_full_dict():
     base = dict(SYSID_PARAMS)
-    trial = {name: 0.5 for name in (*STAGE1, *STEER_LAG)}
+    trial = {name: 0.5 for name in (*VEHICLE_DYN, *STEER_LAG)}
     out = apply_trial_params(base, trial)
     # All non-search-space keys preserved, except symmetric partners which mirror their pair.
     for k, v in SYSID_PARAMS.items():

--- a/tests/sysid/test_study.py
+++ b/tests/sysid/test_study.py
@@ -18,7 +18,7 @@ import yaml
 
 from examples.analysis.sysid.env import SYSID_PARAMS
 from examples.analysis.sysid.rollout import Rollout
-from examples.analysis.sysid.search_spaces import STAGE1, SYMMETRIC_PAIRS
+from examples.analysis.sysid.search_spaces import SYMMETRIC_PAIRS, VEHICLE_DYN
 from examples.analysis.sysid.study import Objective, build_study, dump_best_params
 
 
@@ -40,7 +40,7 @@ def test_study_smoke_runs_and_persists(tmp_path, dataset, rollout):
     journal_path = tmp_path / "smoke.journal"
     study = build_study("smoke_test", journal_path, seed=42)
 
-    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), STAGE1)
+    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), VEHICLE_DYN)
     study.optimize(obj, n_trials=2)
 
     assert journal_path.exists() and journal_path.stat().st_size > 0
@@ -61,7 +61,7 @@ def test_diverged_trial_is_pruned(tmp_path, dataset, rollout):
     journal_path = tmp_path / "div.journal"
     study = build_study("div_test", journal_path, seed=0)
 
-    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), STAGE1)
+    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), VEHICLE_DYN)
 
     # Patch Rollout.run to raise FloatingPointError every call.
     with patch.object(Rollout, "run", side_effect=FloatingPointError("synthetic divergence")):
@@ -81,7 +81,7 @@ def test_dump_best_params_round_trip(tmp_path, dataset, rollout):
     journal_path = tmp_path / "dump.journal"
     study = build_study("dump_test", journal_path, seed=7)
 
-    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), STAGE1)
+    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), VEHICLE_DYN)
     study.optimize(obj, n_trials=2)
 
     out_yaml = tmp_path / "out.yaml"
@@ -102,7 +102,7 @@ def test_dump_best_params_round_trip(tmp_path, dataset, rollout):
         if src in study.best_params:
             assert loaded[partner] == pytest.approx(-study.best_params[src])
     # Remaining (truly untouched) keys equal SYSID_PARAMS.
-    overlaid = set(STAGE1) | {p for s, p in SYMMETRIC_PAIRS.items() if s in study.best_params}
+    overlaid = set(VEHICLE_DYN) | {p for s, p in SYMMETRIC_PAIRS.items() if s in study.best_params}
     for k, v in SYSID_PARAMS.items():
         if k not in overlaid:
             assert loaded[k] == v
@@ -117,15 +117,15 @@ def test_enqueue_trial_matches_direct_rollout(tmp_path, dataset, rollout):
     Catches bugs where apply_trial_params or set_params silently no-op
     (e.g. wrong key, value not propagated to env).
 
-    NOTE: cannot use YAML defaults — Phase-2 deliberately set the Stage-1
+    NOTE: cannot use YAML defaults — Phase-2 deliberately set the vehicle_dyn
     lower bound for ``I_z`` to 0.05 (above the YAML default of 0.047)
     because the default is wrong. Pick a point inside every search bound.
     """
     from examples.analysis.sysid.loss import dataset_loss
     from examples.analysis.sysid.search_spaces import apply_trial_params
 
-    # Midpoint of every Stage-1 bound — guaranteed in-bounds.
-    point = {name: 0.5 * (dist.low + dist.high) for name, dist in STAGE1.items()}
+    # Midpoint of every vehicle_dyn bound — guaranteed in-bounds.
+    point = {name: 0.5 * (dist.low + dist.high) for name, dist in VEHICLE_DYN.items()}
 
     # Direct path: overlay onto SYSID_PARAMS, set on env, run dataset_loss.
     direct_params = apply_trial_params(dict(SYSID_PARAMS), point)
@@ -136,7 +136,7 @@ def test_enqueue_trial_matches_direct_rollout(tmp_path, dataset, rollout):
     journal_path = tmp_path / "enqueue.journal"
     study = build_study("enqueue_test", journal_path, seed=0)
     study.enqueue_trial(point)
-    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), STAGE1)
+    obj = Objective(dataset, rollout, dict(SYSID_PARAMS), VEHICLE_DYN)
     study.optimize(obj, n_trials=1)
 
     assert study.trials[0].value == pytest.approx(direct_loss, rel=1e-6, abs=1e-9), (
@@ -169,7 +169,7 @@ def test_main_requires_study_name_for_multi_bag(tmp_path, synthetic_bag_npz):
                 "--bag",
                 str(second),
                 "--stage",
-                "stage1",
+                "vehicle_dyn",
                 "--n-trials",
                 "1",
             ]

--- a/tests/sysid/test_study.py
+++ b/tests/sysid/test_study.py
@@ -143,3 +143,34 @@ def test_enqueue_trial_matches_direct_rollout(tmp_path, dataset, rollout):
         f"Enqueued trial value {study.trials[0].value} differs from direct "
         f"dataset_loss {direct_loss} — apply_trial_params or set_params likely no-opped."
     )
+
+
+# ---------- multi-bag CLI contract: --study-name required when N>1 ----------
+
+
+def test_main_requires_study_name_for_multi_bag(tmp_path, synthetic_bag_npz):
+    """Multi-bag invocations must provide --study-name explicitly — auto-naming
+    from a single bag stem is undefined for N>1. The error must surface BEFORE
+    any heavy work (dataset load, wandb init, study build); we rely on this so
+    misconfigured invocations fail fast.
+    """
+    from .conftest import make_npz
+
+    second = tmp_path / "second.npz"
+    make_npz(str(second), n=1000, speed=2.0, vy=0.1, yaw_rate=0.3, steer=0.15)
+
+    from examples.analysis.sysid.study import main
+
+    with pytest.raises(SystemExit, match="study-name is required"):
+        main(
+            [
+                "--bag",
+                synthetic_bag_npz,
+                "--bag",
+                str(second),
+                "--stage",
+                "stage1",
+                "--n-trials",
+                "1",
+            ]
+        )

--- a/tests/sysid/test_validate.py
+++ b/tests/sysid/test_validate.py
@@ -1,0 +1,179 @@
+"""Unit tests for examples.analysis.sysid.validate helpers.
+
+Covers the metrics-writing layer:
+- `_format_per_bag_raw_mse_table`: column-sort independence, raw_MSE = contrib/coeff math.
+- `_format_continuity_lines`: empty PASS branch + bag-tagged failure lines.
+- `_write_metrics`: single-bag vs multi-bag header shape, diagnostic-table gating.
+
+We exercise these helpers directly rather than through `main()` so the tests stay fast
+and don't need a Rollout / GKEnv.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from examples.analysis.sysid.dataset import CHANNELS, Dataset
+from examples.analysis.sysid.loss import CHANNEL_COEFFS
+from examples.analysis.sysid.validate import (
+    _format_continuity_lines,
+    _format_per_bag_raw_mse_table,
+    _write_metrics,
+)
+
+
+def _make_args(mirror: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        window_length_s=1.5,
+        stride_s=0.5,
+        min_speed=0.3,
+        warmup_s=0.2,
+        mirror=mirror,
+    )
+
+
+def _empty_dataset() -> Dataset:
+    return Dataset(windows=[], dt=0.01, n_candidates=0, n_dropped_low_speed=0, n_dropped_nonfinite=0)
+
+
+# -- _format_per_bag_raw_mse_table --
+
+
+def test_per_bag_table_sorts_columns():
+    """Column order must be sorted alphabetically by bag stem regardless of dict insertion order."""
+    contribs = {ch: 1.0 for ch in CHANNELS}
+    per_bag = {"z_bag": contribs, "m_bag": contribs, "a_bag": contribs}
+    lines = _format_per_bag_raw_mse_table(per_bag)
+    header = next(line for line in lines if "channel" in line and "a_bag" in line)
+    assert header.index("a_bag") < header.index("m_bag") < header.index("z_bag")
+
+
+def test_per_bag_table_raw_mse_matches_contrib_over_coeff():
+    """raw_MSE printed in the table equals contribution / CHANNEL_COEFFS[ch]."""
+    # Pick distinct contribs so the two bags' raw values are easy to verify.
+    per_bag = {
+        "bag_a": {ch: 0.6 for ch in CHANNELS},
+        "bag_b": {ch: 0.3 for ch in CHANNELS},
+    }
+    lines = _format_per_bag_raw_mse_table(per_bag)
+    # yaw_rate row carries the raw values for both bags.
+    yaw_row = next(line for line in lines if line.lstrip().startswith("yaw_rate"))
+    expected_a = 0.6 / CHANNEL_COEFFS["yaw_rate"]
+    expected_b = 0.3 / CHANNEL_COEFFS["yaw_rate"]
+    assert f"{expected_a:.6f}" in yaw_row
+    assert f"{expected_b:.6f}" in yaw_row
+
+
+def test_per_bag_table_lists_all_channels():
+    per_bag = {"a": {ch: 0.1 for ch in CHANNELS}, "b": {ch: 0.2 for ch in CHANNELS}}
+    lines = _format_per_bag_raw_mse_table(per_bag)
+    body = "\n".join(lines)
+    for ch in CHANNELS:
+        assert ch in body, f"channel {ch!r} missing from raw_MSE table"
+
+
+# -- _format_continuity_lines --
+
+
+def test_continuity_empty_returns_pass():
+    assert _format_continuity_lines([]) == ["yaw_continuity: PASS"]
+
+
+def test_continuity_failures_include_bag_tag_and_t0_idx():
+    failures = [("bagA", 100, 1.6, 0.5), ("bagB", 200, 0.7, 1.8)]
+    lines = _format_continuity_lines(failures)
+    # First line summarizes count.
+    assert "2 window(s)" in lines[0]
+    # Each failure becomes its own line with bag stem and t0_idx prefix.
+    assert any("bag=bagA" in ln and "t0_idx=100" in ln for ln in lines[1:])
+    assert any("bag=bagB" in ln and "t0_idx=200" in ln for ln in lines[1:])
+
+
+# -- _write_metrics --
+
+
+def test_write_metrics_single_bag_header(tmp_path):
+    """Single-bag mode writes one `bag: <path>` line; no `bags:` block, no diagnostic table."""
+    bag = tmp_path / "bagX.npz"
+    bag.touch()
+    out = tmp_path / "metrics.txt"
+    _write_metrics(
+        str(out),
+        bags=[bag],
+        params_source="SYSID_PARAMS",
+        args=_make_args(),
+        dataset=_empty_dataset(),
+        total_loss=1.234,
+        per_channel={ch: 0.0 for ch in CHANNELS},
+        continuity_failures=[],
+    )
+    content = out.read_text()
+    assert content.startswith(f"bag: {bag}\n")
+    assert "bags:" not in content
+    assert "per-bag raw_MSE" not in content
+    assert "total_loss: 1.234000" in content
+
+
+def test_write_metrics_multi_bag_header_and_diagnostic(tmp_path):
+    """Multi-bag mode writes `bags:` block and the per-bag raw_MSE diagnostic table."""
+    bag_a = tmp_path / "a.npz"
+    bag_b = tmp_path / "b.npz"
+    bag_a.touch()
+    bag_b.touch()
+    out = tmp_path / "metrics.txt"
+    per_bag = {"a": {ch: 0.1 for ch in CHANNELS}, "b": {ch: 0.2 for ch in CHANNELS}}
+    _write_metrics(
+        str(out),
+        bags=[bag_a, bag_b],
+        params_source="SYSID_PARAMS",
+        args=_make_args(),
+        dataset=_empty_dataset(),
+        total_loss=0.5,
+        per_channel={ch: 0.0 for ch in CHANNELS},
+        continuity_failures=[],
+        per_bag_per_channel=per_bag,
+    )
+    content = out.read_text()
+    assert content.startswith("bags:\n")
+    assert f"  - {bag_a}" in content
+    assert f"  - {bag_b}" in content
+    assert "per-bag raw_MSE" in content
+
+
+def test_write_metrics_skips_diagnostic_when_single_bag_in_per_bag_dict(tmp_path):
+    """Diagnostic table is gated on len(per_bag_per_channel) > 1, not just `is not None`."""
+    bag = tmp_path / "only.npz"
+    bag.touch()
+    out = tmp_path / "metrics.txt"
+    _write_metrics(
+        str(out),
+        bags=[bag],
+        params_source="SYSID_PARAMS",
+        args=_make_args(),
+        dataset=_empty_dataset(),
+        total_loss=0.1,
+        per_channel={ch: 0.0 for ch in CHANNELS},
+        continuity_failures=[],
+        per_bag_per_channel={"only": {ch: 0.1 for ch in CHANNELS}},
+    )
+    content = out.read_text()
+    assert "per-bag raw_MSE" not in content
+
+
+def test_write_metrics_continuity_failures_render(tmp_path):
+    bag = tmp_path / "bag.npz"
+    bag.touch()
+    out = tmp_path / "metrics.txt"
+    _write_metrics(
+        str(out),
+        bags=[bag],
+        params_source="SYSID_PARAMS",
+        args=_make_args(),
+        dataset=_empty_dataset(),
+        total_loss=0.0,
+        per_channel={ch: 0.0 for ch in CHANNELS},
+        continuity_failures=[("bag", 42, 1.7, 0.9)],
+    )
+    content = out.read_text()
+    assert "WARN: yaw continuity check failed for 1 window(s)" in content
+    assert "bag=bag" in content and "t0_idx=42" in content

--- a/tests/test_params_yaml.py
+++ b/tests/test_params_yaml.py
@@ -74,6 +74,7 @@ _STP_PACEJKA_KEYS = {"B_f", "C_f", "D_f", "E_f", "B_r", "C_r", "D_r", "E_r"}
         ("f1fifth", _COMMON_KEYS | _LINEAR_TIRE_KEYS | {"I"}),
         ("f1tenth_st", _COMMON_KEYS | _LINEAR_TIRE_KEYS | {"I"}),
         ("f1tenth_std", _COMMON_KEYS | _STD_MEASURABLE_KEYS | _PAC2002_TIRE_KEYS),
+        ("f1tenth_std_new_tire_covers", _COMMON_KEYS | _STD_MEASURABLE_KEYS | _PAC2002_TIRE_KEYS),
         (
             "f1tenth_std_drift_bias",
             _COMMON_KEYS | _LINEAR_TIRE_KEYS | _STD_MEASURABLE_KEYS | _PAC2002_TIRE_KEYS,
@@ -95,6 +96,7 @@ def test_yaml_values_are_numeric():
         "f1fifth",
         "f1tenth_st",
         "f1tenth_std",
+        "f1tenth_std_new_tire_covers",
         "f1tenth_std_drift_bias",
         "f1tenth_stp",
     ):

--- a/train/ppo_example.py
+++ b/train/ppo_example.py
@@ -2,10 +2,10 @@ import os
 
 import gymnasium as gym
 import numpy as np
+import wandb
 from stable_baselines3 import PPO
 from wandb.integration.sb3 import WandbCallback
 
-import wandb
 from train.config.env_config import PROJECT_NAME, SEED
 from train.train_utils import get_ckpt_callback, get_output_dirs, make_output_dirs
 

--- a/train/train_common.py
+++ b/train/train_common.py
@@ -9,11 +9,11 @@ from functools import partial
 
 import gymnasium as gym
 import numpy as np
+import wandb
 from stable_baselines3 import PPO
 from stable_baselines3.common.policies import BasePolicy
 from wandb.integration.sb3 import WandbCallback
 
-import wandb
 from train.callbacks import (
     LogStdScheduleCallback,
     make_curriculum_callback,

--- a/train/train_utils.py
+++ b/train/train_utils.py
@@ -10,12 +10,12 @@ from pathlib import Path
 import gymnasium as gym
 import numpy as np
 import torch.nn as nn
+import wandb
 import yaml
 from stable_baselines3.common.callbacks import CheckpointCallback, EvalCallback
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecEnv
 
-import wandb
 from gymkhana.envs.gymkhana_env import GKEnv, print_obs_min_max_stats
 from gymkhana.envs.track import Track
 from gymkhana.envs.track.track_utils import get_min_max_curvature, get_min_max_track_width


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-bag system identification runs with repeatable `--bag` handling, deterministic ordering, provenance tracking, and per-bag diagnostics.
  * SysID search spaces reorganized into steer-lag / vehicle-dynamics / fine-tune phases.
  * Added new F1TENTH “slippery 3D-printed tire covers” STD vehicle parameter configuration.
* **Documentation**
  * Updated Optuna workflow and CLI guidance for multi-bag usage, including `.txt` bag-list support and stage/launch examples.
* **Tests**
  * Expanded coverage for multi-bag dataset loading, validation outputs, and updated search-space constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->